### PR TITLE
Implement features towards YouTrack api generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,21 @@ Generates client and server side Java/Kotlin code based on OpenAPI spec, using [
 ## Usage example (in Kotlin code, e.g. Gradle's buildSrc)
 
 ```kotlin
-val codegen = KotlinCodegen("com.example.project", true)
+val codegen = KotlinCodegen(GeneratorParams.rootPackage("com.example.project"))
 val yamlPath = project.layout.projectDirectory.asFile.toPath().resolve("src/main/openapi/api.yaml")
 val resultPath = project.layout.buildDirectory.get().asFile.toPath().resolve("generated-sources")
 Files.createDirectories(resultPath)
 codegen.generate(yamlPath, resultPath)
 ```
+
+## Configuration parameters
+
+| Parameter name | Type | Default value | Description |
+|--------------------------|------|---------------|-------------|
+|`rootPackage`|String | | Sets the root package for all the generated classes. `Controller` and `Api` interfaces will be generated in `controller` subpackage, and all the DTOs will be generated in `dto` subpackage.
+|`generateResponseParameter`|boolean|false|Set to true if you need to have `HttpServletResponse` parameter in each generated `Controller` method. You might need this in order to return specific HTTP status codes.
+|`generateApiInterface`|boolean|false|Set to true if you need to generate an interface called `Api` besides `Controller`. `Api` methods do not have `HttpServletResponse` parameter.
+|`forceSnakeCaseForProperties`|boolean|true|By default, hurdy-gurdy expects all the properties of DTO classes to be defined in _snake_case_ in the specification. It converts these names to _camelCase_ for generated classes and sets Jackson's `SnakeCaseStrategy` so that they will still be _snake_case_ in JSON representation. If you don't want this (e. g. if you want your properties to be defined in _camelCase_ everywhere) you can turn off this function via this parameter. 
 
 ## Inheritance hierarchy compatible with openapi-codegen
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.curs</groupId>
     <artifactId>hurdy-gurdy</artifactId>
-    <version>1.22</version>
+    <version>1.23</version>
     <packaging>maven-plugin</packaging>
 
     <name>OpenAPI codegen Maven Plugin</name>

--- a/src/main/java/ru/curs/hurdygurdy/APIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/APIExtractor.java
@@ -22,21 +22,18 @@ import java.util.stream.Stream;
 
 public abstract class APIExtractor<T, B> implements TypeSpecExtractor<T> {
     final TypeDefiner<T> typeDefiner;
-    final boolean generateApiInterface;
-    private final boolean generateResponseParameter;
+    private final GeneratorParams params;
 
     private final Map<String, B> builders = new HashMap<>();
     private final Function<String, B> builderSupplier;
     private final Function<B, T> buildInvoker;
 
     protected APIExtractor(TypeDefiner<T> typeDefiner,
-                           boolean generateResponseParameter,
-                           boolean generateApiInterface,
+                           GeneratorParams params,
                            Function<String, B> builderSupplier,
                            Function<B, T> buildInvoker) {
         this.typeDefiner = typeDefiner;
-        this.generateResponseParameter = generateResponseParameter;
-        this.generateApiInterface = generateApiInterface;
+        this.params = params;
         this.builderSupplier = builderSupplier;
         this.buildInvoker = buildInvoker;
     }
@@ -48,10 +45,10 @@ public abstract class APIExtractor<T, B> implements TypeSpecExtractor<T> {
     public final void extractTypeSpecs(OpenAPI openAPI, BiConsumer<ClassCategory, T> typeSpecBiConsumer) {
         Paths paths = openAPI.getPaths();
         if (paths == null) return;
-        generateClass(openAPI, paths, "Controller", generateResponseParameter);
+        generateClass(openAPI, paths, "Controller", params.isGenerateResponseParameter());
         builders.values().stream().map(buildInvoker).forEach(t ->
                 typeSpecBiConsumer.accept(ClassCategory.CONTROLLER, t));
-        if (generateApiInterface) {
+        if (params.isGenerateApiInterface()) {
             builders.clear();
             generateClass(openAPI, paths, "Api", false);
             builders.values().stream().map(buildInvoker).forEach(t ->

--- a/src/main/java/ru/curs/hurdygurdy/CaseUtils.java
+++ b/src/main/java/ru/curs/hurdygurdy/CaseUtils.java
@@ -5,6 +5,42 @@ public final class CaseUtils {
 
     }
 
+    public static String pathToCamel(String pathText) {
+        if (pathText == null) {
+            return null;
+        }
+        int state = 0;
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < pathText.length(); i++) {
+            char c = pathText.charAt(i);
+            switch (state) {
+                case 0: {
+                    if (!(c == '/' || c == '{')) {
+                        result.append(c);
+                        state = 1;
+                    }
+                    break;
+                }
+                case 1: {
+                    if (c == '/') {
+                        state = 2;
+                    } else if (c != '}') {
+                        result.append(c);
+                    }
+                    break;
+                }
+                case 2: {
+                    if (!(c == '/' || c == '{')) {
+                        result.append(Character.toUpperCase(c));
+                        state = 1;
+                    }
+                    break;
+                }
+            }
+        }
+        return result.toString();
+    }
+
     public static String snakeToCamel(String snakeText) {
         return snakeToCamel(snakeText, false);
     }

--- a/src/main/java/ru/curs/hurdygurdy/CaseUtils.java
+++ b/src/main/java/ru/curs/hurdygurdy/CaseUtils.java
@@ -14,28 +14,25 @@ public final class CaseUtils {
         for (int i = 0; i < pathText.length(); i++) {
             char c = pathText.charAt(i);
             switch (state) {
-                case 0: {
+                case 0:
                     if (!(c == '/' || c == '{')) {
                         result.append(c);
                         state = 1;
                     }
                     break;
-                }
-                case 1: {
+                case 1:
                     if (c == '/') {
                         state = 2;
                     } else if (c != '}') {
                         result.append(c);
                     }
                     break;
-                }
-                case 2: {
+                case 2:
                     if (!(c == '/' || c == '{')) {
                         result.append(Character.toUpperCase(c));
                         state = 1;
                     }
                     break;
-                }
             }
         }
         return result.toString();

--- a/src/main/java/ru/curs/hurdygurdy/Codegen.java
+++ b/src/main/java/ru/curs/hurdygurdy/Codegen.java
@@ -16,15 +16,15 @@ import java.util.Map;
 
 public abstract class Codegen<T> {
 
-    private final String rootPackage;
+    private final GeneratorParams params;
     private OpenAPI openAPI;
     private final Map<ClassCategory, List<T>> typeSpecs = new EnumMap<>(ClassCategory.class);
     private final List<TypeSpecExtractor<T>> typeSpecExtractors;
     private final TypeDefiner<T> typeDefiner;
 
 
-    public Codegen(String rootPackage, TypeProducersFactory<T> typeProducersFactory) {
-        this.rootPackage = rootPackage;
+    public Codegen(GeneratorParams params, TypeProducersFactory<T> typeProducersFactory) {
+        this.params = params;
         typeDefiner = typeProducersFactory.createTypeDefiner(this::addTypeSpec);
         typeSpecExtractors = typeProducersFactory.typeSpecExtractors(typeDefiner);
     }
@@ -56,7 +56,7 @@ public abstract class Codegen<T> {
     void generate(Path resultDirectory) throws IOException {
         for (Map.Entry<ClassCategory, List<T>> typeSpecsEntry : typeSpecs.entrySet()) {
             for (T typeSpec : typeSpecsEntry.getValue()) {
-                final String packageName = String.join(".", rootPackage,
+                final String packageName = String.join(".", params.getRootPackage(),
                         typeSpecsEntry.getKey().getPackageName());
                 writeFile(resultDirectory, packageName, typeSpec);
             }

--- a/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
+++ b/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
@@ -38,10 +38,14 @@ public class CodegenMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        GeneratorParams params =
+                GeneratorParams.rootPackage(rootPackage)
+                        .generateResponseParameter(generateResponseParameter)
+                        .generateApiInterface(generateApiInterface);
         Codegen<?> codegen =
                 "java".equalsIgnoreCase(language)
-                        ? new JavaCodegen(rootPackage, generateResponseParameter, generateApiInterface)
-                        : new KotlinCodegen(rootPackage, generateResponseParameter, generateApiInterface);
+                        ? new JavaCodegen(params)
+                        : new KotlinCodegen(params);
         try {
             Path targetPath = getTargetPath();
             codegen.generate(Path.of(spec), targetPath);

--- a/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
+++ b/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
@@ -33,6 +33,9 @@ public class CodegenMojo extends AbstractMojo {
     @Parameter(property = "generateApiInterface", required = false)
     boolean generateApiInterface = false;
 
+    @Parameter(property = "forceSnakeCaseForProperties", required = false)
+    boolean forceSnakeCaseForProperties = true;
+
     @Component
     MavenProject project;
 
@@ -41,7 +44,8 @@ public class CodegenMojo extends AbstractMojo {
         GeneratorParams params =
                 GeneratorParams.rootPackage(rootPackage)
                         .generateResponseParameter(generateResponseParameter)
-                        .generateApiInterface(generateApiInterface);
+                        .generateApiInterface(generateApiInterface)
+                        .forceSnakeCaseForProperties(forceSnakeCaseForProperties);
         Codegen<?> codegen =
                 "java".equalsIgnoreCase(language)
                         ? new JavaCodegen(params)

--- a/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
+++ b/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
@@ -1,0 +1,47 @@
+package ru.curs.hurdygurdy;
+
+public final class GeneratorParams {
+    private final String rootPackage;
+    private boolean generateResponseParameter = false;
+    private boolean generateApiInterface = false;
+    private boolean forceSnakeCaseForProperties = true;
+
+    private GeneratorParams(String rootPackage) {
+        this.rootPackage = rootPackage;
+    }
+
+    public GeneratorParams generateResponseParameter(boolean value) {
+        this.generateResponseParameter = value;
+        return this;
+    }
+
+    public GeneratorParams generateApiInterface(boolean value) {
+        this.generateApiInterface = value;
+        return this;
+    }
+
+    public GeneratorParams forceSnakeCaseForProperties(boolean value) {
+        this.forceSnakeCaseForProperties = value;
+        return this;
+    }
+
+    public String getRootPackage() {
+        return rootPackage;
+    }
+
+    public boolean isGenerateResponseParameter() {
+        return generateResponseParameter;
+    }
+
+    public boolean isGenerateApiInterface() {
+        return generateApiInterface;
+    }
+
+    public boolean isForceSnakeCaseForProperties() {
+        return forceSnakeCaseForProperties;
+    }
+
+    public static GeneratorParams rootPackage(String rootPackage) {
+        return new GeneratorParams(rootPackage);
+    }
+}

--- a/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
@@ -31,9 +31,8 @@ import java.util.stream.Stream;
 public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
 
     public JavaAPIExtractor(TypeDefiner<TypeSpec> typeDefiner,
-                            boolean generateResponseParameter,
-                            boolean generateApiInterface) {
-        super(typeDefiner, generateResponseParameter, generateApiInterface,
+                            GeneratorParams params) {
+        super(typeDefiner, params,
                 TypeSpec::interfaceBuilder,
                 TypeSpec.Builder::build);
     }

--- a/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
@@ -65,7 +65,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
         getParameterStream(stringPathItemEntry.getValue(), operationEntry.getValue())
                 .filter(parameter -> "path".equalsIgnoreCase(parameter.getIn()))
                 .forEach(parameter -> methodBuilder.addParameter(ParameterSpec.builder(
-                        safeUnbox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI, classBuilder)),
+                        safeUnbox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI, classBuilder, null)),
                         CaseUtils.snakeToCamel(parameter.getName()))
                         .addAnnotation(
                                 AnnotationSpec.builder(PathVariable.class)
@@ -88,7 +88,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                             AnnotationSpec annotationSpec = builder.build();
                             methodBuilder.addParameter(ParameterSpec.builder(
                                     safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI,
-                                            classBuilder)),
+                                            classBuilder, null)),
                                     CaseUtils.snakeToCamel(parameter.getName()))
                                     .addAnnotation(annotationSpec).build());
                         }
@@ -96,7 +96,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
         getParameterStream(stringPathItemEntry.getValue(), operationEntry.getValue())
                 .filter(parameter -> "header".equalsIgnoreCase(parameter.getIn()))
                 .forEach(parameter -> methodBuilder.addParameter(ParameterSpec.builder(
-                        safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI, classBuilder)),
+                        safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI, classBuilder, null)),
                         CaseUtils.kebabToCamel(parameter.getName()))
                         .addAnnotation(
                                 AnnotationSpec.builder(
@@ -156,14 +156,15 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                         .entrySet()
                         .stream()
                         .map(e -> new RequestPartParams(
-                                JavaAPIExtractor.safeUnbox(typeDefiner.defineJavaType(e.getValue(), openAPI, parent)),
+                                JavaAPIExtractor.safeUnbox(typeDefiner.defineJavaType(e.getValue(), openAPI,
+                                        parent, null)),
                                 e.getKey(),
                                 AnnotationSpec.builder(RequestPart.class)
                                         .addMember("name", "$S", e.getKey()).build()));
             } else {
                 //Single-part
                 return Optional.ofNullable(entry.getValue().getSchema()).stream()
-                        .map(s -> typeDefiner.defineJavaType(s, openAPI, parent))
+                        .map(s -> typeDefiner.defineJavaType(s, openAPI, parent, null))
                         .map(JavaAPIExtractor::safeUnbox).map(t ->
                                 new RequestPartParams(t,
                                         "request",

--- a/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
@@ -43,9 +43,10 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
     void buildMethod(OpenAPI openAPI, TypeSpec.Builder classBuilder,
                      Map.Entry<String, PathItem> stringPathItemEntry,
                      Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
+                     String operationId,
                      boolean generateResponseParameter) {
         MethodSpec.Builder methodBuilder = MethodSpec
-                .methodBuilder(CaseUtils.snakeToCamel(operationEntry.getValue().getOperationId()))
+                .methodBuilder(operationId)
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT);
         methodBuilder.addAnnotation(getControllerMethodAnnotationSpec(operationEntry, stringPathItemEntry.getKey()));
         //we are deriving the returning type from the schema of the successful result

--- a/src/main/java/ru/curs/hurdygurdy/JavaCodegen.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaCodegen.java
@@ -9,18 +9,18 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 public class JavaCodegen extends Codegen<TypeSpec> {
-    public JavaCodegen(String rootPackage, boolean generateResponseParameter, boolean generateApiInterface) {
+    public JavaCodegen(GeneratorParams params) {
 
-        super(rootPackage, new TypeProducersFactory<>() {
+        super(params, new TypeProducersFactory<>() {
             @Override
             public TypeDefiner<TypeSpec> createTypeDefiner(BiConsumer<ClassCategory, TypeSpec> typeSpecBiConsumer) {
-                return new JavaTypeDefiner(rootPackage, typeSpecBiConsumer);
+                return new JavaTypeDefiner(params, typeSpecBiConsumer);
             }
 
             @Override
             public List<TypeSpecExtractor<TypeSpec>> typeSpecExtractors(TypeDefiner<TypeSpec> typeDefiner) {
                 return List.of(new JavaDTOExtractor(typeDefiner),
-                        new JavaAPIExtractor(typeDefiner, generateResponseParameter, generateApiInterface));
+                        new JavaAPIExtractor(typeDefiner, params));
             }
         });
     }

--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -43,8 +43,8 @@ import java.util.function.BiConsumer;
 public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
     private boolean hasJsonZonedDateTimeDeserializer;
 
-    public JavaTypeDefiner(String rootPackage, BiConsumer<ClassCategory, TypeSpec> typeSpecBiConsumer) {
-        super(rootPackage, typeSpecBiConsumer);
+    public JavaTypeDefiner(GeneratorParams params, BiConsumer<ClassCategory, TypeSpec> typeSpecBiConsumer) {
+        super(params, typeSpecBiConsumer);
     }
 
     @Override
@@ -100,7 +100,7 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
                     String simpleName = schema.getTitle() == null ? typeNameFallback : schema.getTitle();
                     if (simpleName != null) {
                         typeSpecBiConsumer.accept(ClassCategory.DTO, getDTO(simpleName, schema, openAPI));
-                        return ClassName.get(String.join(".", rootPackage, "dto"),
+                        return ClassName.get(String.join(".", params.getRootPackage(), "dto"),
                                 simpleName);
                     } else {
                         //This means failure, in fact.

--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -240,7 +240,7 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
         Map<String, Schema> schemaMap = schema.getProperties();
         if (schemaMap != null) {
             for (Map.Entry<String, Schema> entry : schemaMap.entrySet()) {
-                if (!entry.getKey().matches("[a-z][a-z_0-9]*")) throw new IllegalStateException(
+                if (!entry.getKey().matches("[$a-z][a-z_0-9]*")) throw new IllegalStateException(
                         String.format("Property '%s' of schema '%s' is not in snake case",
                                 entry.getKey(), name)
                 );

--- a/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
@@ -1,5 +1,6 @@
 package ru.curs.hurdygurdy
 
+import com.spun.util.StringUtils
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
@@ -37,10 +38,11 @@ class KotlinAPIExtractor(
         classBuilder: TypeSpec.Builder,
         stringPathItemEntry: Map.Entry<String, PathItem>,
         operationEntry: Map.Entry<PathItem.HttpMethod, Operation>,
+        operationId: String,
         generateResponseParameter: Boolean
     ) {
         val methodBuilder = FunSpec
-            .builder(CaseUtils.snakeToCamel(operationEntry.value.operationId))
+            .builder(operationId)
             .addModifiers(KModifier.PUBLIC, KModifier.ABSTRACT)
         getControllerMethodAnnotationSpec(operationEntry, stringPathItemEntry.key)?.let(methodBuilder::addAnnotation)
         //we are deriving the returning type from the schema of the successful result

--- a/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
@@ -1,6 +1,5 @@
 package ru.curs.hurdygurdy
 
-import com.spun.util.StringUtils
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
@@ -22,13 +21,11 @@ import kotlin.streams.asSequence
 
 class KotlinAPIExtractor(
     typeDefiner: TypeDefiner<TypeSpec>,
-    generateResponseParameter: Boolean,
-    generateApiInterface: Boolean
+    params: GeneratorParams
 ) :
     APIExtractor<TypeSpec, TypeSpec.Builder>(
         typeDefiner,
-        generateResponseParameter,
-        generateApiInterface,
+        params,
         TypeSpec::interfaceBuilder,
         TypeSpec.Builder::build
     ) {

--- a/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
@@ -71,7 +71,7 @@ class KotlinAPIExtractor(
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
                         CaseUtils.snakeToCamel(parameter.name),
-                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder),
+                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null),
                     )
                         .addAnnotation(
                             AnnotationSpec.builder(PathVariable::class)
@@ -96,7 +96,7 @@ class KotlinAPIExtractor(
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
                         CaseUtils.snakeToCamel(parameter.name),
-                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder),
+                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null),
                     )
                         .addAnnotation(
                             annotationSpec
@@ -114,7 +114,7 @@ class KotlinAPIExtractor(
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
                         CaseUtils.kebabToCamel(parameter.name),
-                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder),
+                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null),
                     )
                         .addAnnotation(
                             AnnotationSpec.builder(
@@ -196,7 +196,7 @@ class KotlinAPIExtractor(
                     .map { (name, schema) ->
                         RequestPartParams(
                             name = name,
-                            typeName = typeDefiner.defineKotlinType(schema, openAPI, parent),
+                            typeName = typeDefiner.defineKotlinType(schema, openAPI, parent, null),
                             annotation = AnnotationSpec.builder(RequestPart::class)
                                 .addMember("name = %S", name).build()
                         )
@@ -205,7 +205,7 @@ class KotlinAPIExtractor(
             } else {
                 //Single-part
                 return Optional.ofNullable(entry.value.schema).stream().asSequence()
-                    .map { typeDefiner.defineKotlinType(it, openAPI, parent) }
+                    .map { typeDefiner.defineKotlinType(it, openAPI, parent, null) }
                     .map {
                         RequestPartParams(
                             name = "request",

--- a/src/main/java/ru/curs/hurdygurdy/KotlinCodegen.java
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinCodegen.java
@@ -9,17 +9,17 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 public class KotlinCodegen extends Codegen<TypeSpec> {
-    public KotlinCodegen(String rootPackage, boolean generateResponseParameter, boolean generateApiInterface) {
-        super(rootPackage, new TypeProducersFactory<>() {
+    public KotlinCodegen(GeneratorParams params) {
+        super(params, new TypeProducersFactory<>() {
             @Override
             public TypeDefiner<TypeSpec> createTypeDefiner(BiConsumer<ClassCategory, TypeSpec> typeSpecBiConsumer) {
-                return new KotlinTypeDefiner(rootPackage, typeSpecBiConsumer);
+                return new KotlinTypeDefiner(params, typeSpecBiConsumer);
             }
 
             @Override
             public List<TypeSpecExtractor<TypeSpec>> typeSpecExtractors(TypeDefiner<TypeSpec> typeDefiner) {
                 return List.of(new KotlinDTOExtractor(typeDefiner),
-                        new KotlinAPIExtractor(typeDefiner, generateResponseParameter, generateApiInterface));
+                        new KotlinAPIExtractor(typeDefiner, params));
             }
         });
     }

--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -46,9 +46,9 @@ import java.util.*
 import java.util.function.BiConsumer
 
 class KotlinTypeDefiner internal constructor(
-    rootPackage: String?,
+    params: GeneratorParams,
     typeSpecBiConsumer: BiConsumer<ClassCategory?, TypeSpec?>?
-) : TypeDefiner<TypeSpec?>(rootPackage, typeSpecBiConsumer) {
+) : TypeDefiner<TypeSpec?>(params, typeSpecBiConsumer) {
 
     private var hasJsonZonedDateTimeDeserializer = false
 
@@ -94,7 +94,7 @@ class KotlinTypeDefiner internal constructor(
                     if (simpleName != null) {
                         typeSpecBiConsumer.accept(ClassCategory.DTO, getDTO(simpleName, schema, openAPI))
                         ClassName(
-                            java.lang.String.join(".", rootPackage, "dto"),
+                            java.lang.String.join(".", params.rootPackage, "dto"),
                             simpleName
                         )
                     } else {
@@ -107,7 +107,7 @@ class KotlinTypeDefiner internal constructor(
                     if (simpleName != null) {
                         typeSpecBiConsumer.accept(ClassCategory.DTO, getDTO(simpleName, schema, openAPI))
                         ClassName(
-                            java.lang.String.join(".", rootPackage, "dto"),
+                            java.lang.String.join(".", params.rootPackage, "dto"),
                             simpleName
                         )
                     } else {

--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -207,7 +207,7 @@ class KotlinTypeDefiner internal constructor(
             val schemaMap: Map<String, Schema<*>>? = schema.properties
             val constructorBuilder = FunSpec.constructorBuilder()
             if (schemaMap != null) for ((key, value) in schemaMap) {
-                check(key.matches(Regex("[a-z][a-z_0-9]*"))) {
+                check(key.matches(Regex("[\$a-z][a-z_0-9]*"))) {
                     String.format("Property '%s' of schema '%s' is not in snake case", key, name)
                 }
                 if (schema.discriminator != null && key == schema.discriminator.propertyName) {

--- a/src/main/java/ru/curs/hurdygurdy/TypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/TypeDefiner.java
@@ -58,6 +58,17 @@ public abstract class TypeDefiner<T> {
         return extendsList;
     }
 
+    final String getEnumName(Schema<?> schema, String typeNameFallback) {
+        String simpleName = schema.getTitle();
+        if (simpleName == null) {
+            simpleName = typeNameFallback;
+        }
+        if (simpleName == null) {
+            throw new IllegalStateException("Inline enum schema must have a title");
+        }
+        return simpleName;
+    }
+
     final Map<String, String> getSubclassMapping(Schema<?> schema) {
         return Optional.ofNullable(schema.getDiscriminator())
                 .map(Discriminator::getMapping).orElse(Collections.emptyMap());
@@ -67,13 +78,17 @@ public abstract class TypeDefiner<T> {
 
     abstract T getDTOClass(String name, Schema<?> schema, OpenAPI openAPI);
 
-    com.squareup.javapoet.TypeName defineJavaType(Schema<?> schema, OpenAPI openAPI,
-                                                  com.squareup.javapoet.TypeSpec.Builder parent) {
+    com.squareup.javapoet.TypeName defineJavaType(Schema<?> schema,
+                                                  OpenAPI openAPI,
+                                                  com.squareup.javapoet.TypeSpec.Builder parent,
+                                                  String typeNameFallback) {
         throw new IllegalStateException();
     }
 
-    com.squareup.kotlinpoet.TypeName defineKotlinType(Schema<?> schema, OpenAPI openAPI,
-                                                      com.squareup.kotlinpoet.TypeSpec.Builder parent) {
+    com.squareup.kotlinpoet.TypeName defineKotlinType(Schema<?> schema,
+                                                      OpenAPI openAPI,
+                                                      com.squareup.kotlinpoet.TypeSpec.Builder parent,
+                                                      String typeNameFallback) {
         throw new IllegalStateException();
     }
 

--- a/src/main/java/ru/curs/hurdygurdy/TypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/TypeDefiner.java
@@ -69,6 +69,15 @@ public abstract class TypeDefiner<T> {
         return simpleName;
     }
 
+    final void checkPropertyName(String name, String propertyName) {
+        if (params.isForceSnakeCaseForProperties()
+                && !propertyName.matches("[$a-z][a-z_0-9]*")) throw new IllegalStateException(
+                String.format("Property '%s' of schema '%s' is not in snake case",
+                        propertyName, name)
+        );
+    }
+
+
     final Map<String, String> getSubclassMapping(Schema<?> schema) {
         return Optional.ofNullable(schema.getDiscriminator())
                 .map(Discriminator::getMapping).orElse(Collections.emptyMap());

--- a/src/main/java/ru/curs/hurdygurdy/TypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/TypeDefiner.java
@@ -26,12 +26,12 @@ public abstract class TypeDefiner<T> {
     private static final Pattern FILE_NAME_PATTERN = Pattern.compile("^([^#]*)#");
 
     final BiConsumer<ClassCategory, T> typeSpecBiConsumer;
-    final String rootPackage;
+    final GeneratorParams params;
     final Map<String, DTOMeta> externalClasses = new HashMap<>();
     private Path sourceFile;
 
-    TypeDefiner(String rootPackage, BiConsumer<ClassCategory, T> typeSpecBiConsumer) {
-        this.rootPackage = rootPackage;
+    TypeDefiner(GeneratorParams params, BiConsumer<ClassCategory, T> typeSpecBiConsumer) {
+        this.params = params;
         this.typeSpecBiConsumer = typeSpecBiConsumer;
     }
 
@@ -103,7 +103,7 @@ public abstract class TypeDefiner<T> {
         String className = extractGroup(ref, CLASS_NAME_PATTERN);
         if (fileName.isBlank()) {
             return new DTOMeta(className,
-                    rootPackage,
+                    params.getRootPackage(),
                     fileName,
                     getNullable(currentOpenAPI, className));
         } else {

--- a/src/test/java/ru/curs/hurdygurdy/CaseUtilsTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CaseUtilsTest.java
@@ -69,4 +69,38 @@ class CaseUtilsTest {
     void kebabToCamelAlreadyCamel(){
         assertThat(CaseUtils.kebabToCamel("thisIsCamel")).isEqualTo("thisIsCamel");
     }
+
+    @Test
+    void pathToCamelNull() {
+        assertThat(CaseUtils.pathToCamel(null)).isNull();
+    }
+
+    @Test
+    void pathToCamelBlank() {
+        assertThat(CaseUtils.pathToCamel("")).isEmpty();
+    }
+
+
+    @Test
+    void pathToCamel() {
+        assertThat(CaseUtils.pathToCamel("/path/to/camel")).isEqualTo("pathToCamel");
+        assertThat(CaseUtils.pathToCamel("//path//to//camel")).isEqualTo("pathToCamel");
+    }
+
+
+    @Test
+    void pathToCamelSinglePart(){
+        assertThat(CaseUtils.pathToCamel("path")).isEqualTo("path");
+        assertThat(CaseUtils.pathToCamel("/path")).isEqualTo("path");
+        assertThat(CaseUtils.pathToCamel("{path}")).isEqualTo("path");
+        assertThat(CaseUtils.pathToCamel("/{path}")).isEqualTo("path");
+
+    }
+
+    @Test
+    void pathToCamelWithParameters() {
+        assertThat(CaseUtils.pathToCamel(
+                "/admin/customFieldSettings/bundles/build/{id}/values/{buildBundleElementId}"))
+                .isEqualTo("adminCustomFieldSettingsBundlesBuildIdValuesBuildBundleElementId");
+    }
 }

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.camelCase.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.camelCase.approved.txt
@@ -1,0 +1,41 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import java.lang.String;
+import org.springframework.web.bind.annotation.GetMapping;
+
+interface Controller {
+  @GetMapping(
+      value = "/api/v1/hello",
+      produces = "*/*"
+  )
+  String hello();
+}
+---
+/com/example/dto
+---
+/com/example/dto/Something.java
+package com.example.dto;
+
+import java.lang.Integer;
+import java.lang.String;
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class Something {
+  private String simple;
+
+  private Integer camelCase;
+
+  private UUID snake_case;
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -15,7 +15,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class CodegenTest {
-    private JavaCodegen codegen = new JavaCodegen("com.example", true, false);
+    private JavaCodegen codegen = new JavaCodegen(
+            GeneratorParams.rootPackage("com.example").generateResponseParameter(true));
     Path result;
 
     @BeforeEach
@@ -45,7 +46,9 @@ class CodegenTest {
 
     @Test
     void doNotGenerateResponseParameter() throws IOException {
-        codegen = new JavaCodegen("com.example", false, true);
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(false)
+                .generateApiInterface(true));
         codegen.generate(Path.of("src/test/resources/sample1.yaml"), result);
         Approvals.verify(getContent(result));
     }

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -71,6 +71,12 @@ class CodegenTest {
         Approvals.verify(getContent(result));
     }
 
+    @Test
+    void paramsOverriding() throws IOException {
+        codegen.generate(Path.of("src/test/resources/twoparams.yaml"), result);
+        Approvals.verify(getContent(result));
+    }
+
     String getContent(Path path) throws IOException {
         return Files.walk(path)
                 .sorted()

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -80,6 +80,14 @@ class CodegenTest {
         Approvals.verify(getContent(result));
     }
 
+    @Test
+    void camelCase() throws IOException {
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .forceSnakeCaseForProperties(false));
+        codegen.generate(Path.of("src/test/resources/camelcase.yaml"), result);
+        Approvals.verify(getContent(result));
+    }
+
     String getContent(Path path) throws IOException {
         return Files.walk(path)
                 .sorted()

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.paramsOverriding.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.paramsOverriding.approved.txt
@@ -1,0 +1,60 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.BuildBundleElement;
+import java.lang.String;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+interface Controller {
+  @GetMapping(
+      value = "/admin/customFieldSettings/bundles/build/{id}/values/{buildBundleElementId}",
+      produces = "application/json"
+  )
+  BuildBundleElement adminCustomFieldSettingsBundlesBuildIdValuesBuildBundleElementIdGet(
+      @PathVariable(name = "id") String id,
+      @PathVariable(name = "buildBundleElementId") String buildBundleElementId,
+      @RequestParam(required = false, name = "fields") String fields, HttpServletResponse response);
+}
+---
+/com/example/dto
+---
+/com/example/dto/BuildBundleElement.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.Integer;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BuildBundleElement {
+  private String id;
+
+  private Integer assembleDate;
+
+  private Integer $name;
+
+  private MailProtocol mailProtocol;
+
+  public enum MailProtocol {
+    SMTP,
+
+    SMTPS,
+
+    SMTP_TLS
+  }
+}

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.camelCase.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.camelCase.approved.txt
@@ -1,0 +1,37 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import kotlin.String
+import org.springframework.web.bind.`annotation`.GetMapping
+
+public interface Controller {
+  @GetMapping(
+    value = ["/api/v1/hello"],
+    produces = ["*/*"],
+  )
+  public fun hello(): String?
+}
+---
+/com/example/dto
+---
+/com/example/dto/Something.kt
+package com.example.dto
+
+import java.util.UUID
+import kotlin.Int
+import kotlin.String
+
+public data class Something(
+  public val simple: String? = null,
+  public val camelCase: Int? = null,
+  public val snake_case: UUID? = null,
+)

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -15,7 +15,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class KCodegenTest {
-    private KotlinCodegen codegen = new KotlinCodegen("com.example", true, false);
+    private KotlinCodegen codegen = new KotlinCodegen(
+            GeneratorParams.rootPackage("com.example").generateResponseParameter(true));
     Path result;
 
     @BeforeEach
@@ -51,7 +52,10 @@ class KCodegenTest {
 
     @Test
     void doNotGenerateResponseParameter() throws IOException {
-        codegen = new KotlinCodegen("com.example", false, true);
+        codegen = new KotlinCodegen(GeneratorParams
+                .rootPackage("com.example")
+                .generateResponseParameter(false)
+                .generateApiInterface(true));
         codegen.generate(Path.of("src/test/resources/sample1.yaml"), result);
         Approvals.verify(getContent(result));
     }

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -78,6 +78,12 @@ class KCodegenTest {
     }
 
     @Test
+    void paramsOverriding() throws IOException {
+        codegen.generate(Path.of("src/test/resources/twoparams.yaml"), result);
+        Approvals.verify(getContent(result));
+    }
+
+    @Test
     void nullableParent() throws IOException {
         codegen.generate(Path.of("src/test/resources/nullableparent.yaml"), result);
         Approvals.verify(getContent(result));

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -88,6 +88,14 @@ class KCodegenTest {
     }
 
     @Test
+    void camelCase() throws IOException {
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .forceSnakeCaseForProperties(false));
+        codegen.generate(Path.of("src/test/resources/camelcase.yaml"), result);
+        Approvals.verify(getContent(result));
+    }
+
+    @Test
     void nullableParent() throws IOException {
         codegen.generate(Path.of("src/test/resources/nullableparent.yaml"), result);
         Approvals.verify(getContent(result));

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.paramsOverriding.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.paramsOverriding.approved.txt
@@ -1,0 +1,55 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.BuildBundleElement
+import javax.servlet.http.HttpServletResponse
+import kotlin.String
+import org.springframework.web.bind.`annotation`.GetMapping
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestParam
+
+public interface Controller {
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/build/{id}/values/{buildBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildIdValuesBuildBundleElementIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "buildBundleElementId") buildBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    response: HttpServletResponse,
+  ): BuildBundleElement?
+}
+---
+/com/example/dto
+---
+/com/example/dto/BuildBundleElement.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.Int
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class BuildBundleElement(
+  public val id: String? = null,
+  public val assembleDate: Int? = null,
+  public val `$name`: Int? = null,
+  public val mailProtocol: MailProtocol? = null,
+) {
+  public enum class MailProtocol {
+    SMTP,
+    SMTPS,
+    SMTP_TLS,
+  }
+}

--- a/src/test/resources/camelcase.yaml
+++ b/src/test/resources/camelcase.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.1
+info:
+  title: "Testing suite common API"
+  description: |
+    Test
+  version: "0.1"
+
+paths:
+  /api/v1/hello:
+    get:
+      operationId: hello
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string
+
+components:
+  schemas:
+    Something:
+      type: object
+      nullable: true
+      properties:
+        simple:
+          type: string
+        camelCase:
+          type: integer
+        snake_case:
+          type: string
+          format: uuid
+
+

--- a/src/test/resources/twoparams.yaml
+++ b/src/test/resources/twoparams.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.1
+info:
+  title: Something
+  version: "1.0"
+
+paths:
+  /admin/customFieldSettings/bundles/build/{id}/values/{buildBundleElementId}:
+    description: This resource lets you work with the values in a specific set of builds (build bundle).
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      - name: buildBundleElementId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      parameters:
+        - name: fields
+          in: query
+          schema:
+            type: string
+          example: $type,assembleDate,color($type,background,foreground,id),id,name,ordinal
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: buildBundleElementId
+          in: path
+          required: true
+          schema:
+            type: string
+
+      responses:
+        200:
+          description: single BuildBundleElement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildBundleElement'
+
+components:
+  schemas:
+    BuildBundleElement:
+      description: Represents a build - a single element of a builds bundle.
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        assemble_date:
+          type: integer
+          format: int64,
+          readOnly: false
+        $name:
+          type: integer

--- a/src/test/resources/twoparams.yaml
+++ b/src/test/resources/twoparams.yaml
@@ -56,5 +56,13 @@ components:
           type: integer
           format: int64,
           readOnly: false
+        # A name with dollar sign prefix
         $name:
           type: integer
+        # Anonymous enum
+        mail_protocol:
+          type: string
+          enum:
+            - "SMTP"
+            - "SMTPS"
+            - "SMTP_TLS"


### PR DESCRIPTION
* allow $ to be a first character in property name

* generate `operationId` for a method if there's none

* if title for internal enum is not provider, use a capitalized property name instead

* if parameters with the same name are declared both on
path and operation level, then operation has priority