### PR TITLE
Better support for complex inheritance

### DIFF
--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.deepInheritance.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.deepInheritance.approved.txt
@@ -1,0 +1,54 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/A.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = B.class, name = "b"),
+    @JsonSubTypes.Type(value = C.class, name = "c")})
+public class A {
+}
+---
+/com/example/dto/B.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class B extends A {
+}
+---
+/com/example/dto/C.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class C extends B {
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -106,6 +106,12 @@ class CodegenTest {
         Approvals.verify(getContent(result));
     }
 
+    @Test
+    void deepInheritance() throws IOException {
+        codegen.generate(Path.of("src/test/resources/deep_inheritance.yaml"), result);
+        Approvals.verify(getContent(result));
+    }
+
     String getContent(Path path) throws IOException {
         return Files.walk(path)
                 .sorted()

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.deepInheritance.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.deepInheritance.approved.txt
@@ -1,0 +1,46 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/A.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "type",
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(value = B::class, name = "b"),
+  JsonSubTypes.Type(value = C::class, name = "c"),
+)
+public sealed class A()
+---
+/com/example/dto/B.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public open class B : A()
+---
+/com/example/dto/C.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data object C : B()

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.generateSample3.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.generateSample3.approved.txt
@@ -69,7 +69,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.`annotation`.JsonNaming
 
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
-public object ClassWithNoFields
+public data object ClassWithNoFields
 ---
 /com/example/dto/CreateUpdateUserRequest.kt
 package com.example.dto

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -119,6 +119,12 @@ class KCodegenTest {
         Approvals.verify(getContent(result));
     }
 
+    @Test
+    void deepInheritance() throws IOException {
+        codegen.generate(Path.of("src/test/resources/deep_inheritance.yaml"), result);
+        Approvals.verify(getContent(result));
+    }
+
     String getContent(Path path) throws IOException {
         return Files.walk(path)
                 .sorted()

--- a/src/test/resources/deep_inheritance.yaml
+++ b/src/test/resources/deep_inheritance.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.1
+info:
+  title: "Deep inheritance API"
+  description: |
+    Test
+  version: "0.1"
+
+paths:
+
+
+components:
+  schemas:
+    A:
+      description: A
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          'b': '#/components/schemas/B'
+          'c': '#/components/schemas/C'
+    B:
+      description: B
+      nullable: false
+      allOf:
+        - $ref: "#/components/schemas/A"
+
+    C:
+      description: C
+      nullable: false
+      allOf:
+        - $ref: "#/components/schemas/B"

--- a/src/test/resources/deep_inheritance.yaml
+++ b/src/test/resources/deep_inheritance.yaml
@@ -22,12 +22,10 @@ components:
           'c': '#/components/schemas/C'
     B:
       description: B
-      nullable: false
       allOf:
         - $ref: "#/components/schemas/A"
 
     C:
       description: C
-      nullable: false
       allOf:
         - $ref: "#/components/schemas/B"


### PR DESCRIPTION
The current implementation had several issues:
1. If there are classes `A` -> `B` -> `C`, `C` will be `sealed`, `A` and `B` will be `data`. This is incorrect, `B` should be `open`.
2. All properties in `B` and `C` should be open: descendants can override them
3. If class has no own properties, there can be two cases:
    3.1. It's a leaf (like `A`), then it should be `data object`, not just object
    3.2. It's a node (like `B`), then it should be `open class`

This commit addresses all these cases.

There is still one important issue I don't immediately know how to fix: all descendants should have an `override` modifier on fields, overriding fields in the whole tree.
