### PR TITLE
Fix code generation for property-redeclaring inheritance and illegal parameter names

### DIFF
--- a/src/main/java/ru/curs/hurdygurdy/CaseUtils.java
+++ b/src/main/java/ru/curs/hurdygurdy/CaseUtils.java
@@ -121,6 +121,34 @@ public final class CaseUtils {
     }
 
     /**
+     * Strips characters that are illegal in a Kotlin identifier even when it is
+     * back-ticked (for example the {@code []} in a multipart field named
+     * {@code files[0]}). The original spec name is still emitted verbatim in the
+     * {@code name = "..."} of the binding annotation, so only the generated
+     * parameter/property identifier is affected. A leading digit left after
+     * stripping is prefixed with {@code _}; an empty result becomes {@code _}.
+     *
+     * <p>For names that are already legal (the common case) this is a no-op.
+     *
+     * @param name the raw spec name to turn into a legal Kotlin identifier
+     */
+    public static String toIdentifier(String name) {
+        if (name == null) {
+            return null;
+        }
+        // Forbidden in a back-ticked Kotlin identifier: . ; [ ] / < > : \ ` and
+        // whitespace/control characters.
+        String cleaned = name.replaceAll("[\\[\\]./<>:;\\\\`\\s\\p{Cntrl}]", "");
+        if (cleaned.isEmpty()) {
+            return "_";
+        }
+        if (Character.isDigit(cleaned.charAt(0))) {
+            return "_" + cleaned;
+        }
+        return cleaned;
+    }
+
+    /**
      * Produces a valid Java class name from a string.
      * @param text any string to be converted to a clean CamelCase
      */

--- a/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
@@ -65,7 +65,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                 .forEach(paramSpec ->
                         methodBuilder.addParameter(ParameterSpec.builder(
                                         paramSpec.typeName,
-                                        paramSpec.name)
+                                        CaseUtils.toIdentifier(paramSpec.name))
                                 .addAnnotation(paramSpec.annotation).build())
                 );
 
@@ -74,7 +74,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                 .forEach(parameter -> methodBuilder.addParameter(ParameterSpec.builder(
                                 safeUnbox(typeDefiner.defineJavaType(parameter.getSchema(),
                                         openAPI, classBuilder, null)),
-                                CaseUtils.snakeToCamel(parameter.getName()))
+                                CaseUtils.toIdentifier(CaseUtils.snakeToCamel(parameter.getName())))
                         .addAnnotation(
                                 AnnotationSpec.builder(PathVariable.class)
                                         .addMember("name", "$S", parameter.getName()).build()
@@ -97,7 +97,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                             methodBuilder.addParameter(ParameterSpec.builder(
                                             safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI,
                                                     classBuilder, null)),
-                                            CaseUtils.snakeToCamel(parameter.getName()))
+                                            CaseUtils.toIdentifier(CaseUtils.snakeToCamel(parameter.getName())))
                                     .addAnnotation(annotationSpec).build());
                         }
                 );
@@ -105,7 +105,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                 .filter(parameter -> "header".equalsIgnoreCase(parameter.getIn()))
                 .forEach(parameter -> methodBuilder.addParameter(ParameterSpec.builder(
                                 safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI, classBuilder, null)),
-                                CaseUtils.kebabToCamel(parameter.getName()))
+                                CaseUtils.toIdentifier(CaseUtils.kebabToCamel(parameter.getName())))
                         .addAnnotation(
                                 AnnotationSpec.builder(
                                                 RequestHeader.class

--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -39,9 +39,12 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 
@@ -221,19 +224,60 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
         if (schema instanceof ComposedSchema && schema.getOneOf() == null) {
             ClassName baseClass = ClassName.get(Object.class);
             Schema<?> currentSchema = schema;
+            Set<String> inheritedKeys = new HashSet<>();
             for (Schema<?> s : schema.getAllOf()) {
                 if (s.get$ref() != null) {
                     baseClass = referencedClassName(openAPI, s.get$ref());
+                    inheritedKeys.addAll(inheritedPropertyKeys(s.get$ref(), openAPI));
                 } else {
                     currentSchema = s;
                 }
             }
-            return getDTOClass(name, currentSchema, openAPI, baseClass);
+            return getDTOClass(name, currentSchema, openAPI, baseClass, inheritedKeys);
         }
-        return getDTOClass(name, schema, openAPI, ClassName.get(Object.class));
+        return getDTOClass(name, schema, openAPI, ClassName.get(Object.class), Set.of());
     }
 
-    private TypeSpec getDTOClass(String name, Schema<?> schema, OpenAPI openAPI, ClassName baseClass) {
+    /**
+     * All property names a class inherits through its {@code allOf} ancestor
+     * chain (their own properties plus what they inherit in turn), resolved
+     * within the current file only. A subclass that re-declares one of these
+     * must not emit its own field: Lombok would generate a clashing
+     * getter/setter that either cannot override the inherited one (narrower
+     * type) or collides on erasure, neither of which compiles.
+     */
+    private Set<String> inheritedPropertyKeys(String ref, OpenAPI openAPI) {
+        if (!extractGroup(ref, FILE_NAME_PATTERN).isBlank()) {
+            // Reference into another file — its schema is not visible here.
+            return Set.of();
+        }
+        Schema<?> schema = Optional.ofNullable(openAPI.getComponents())
+                .map(c -> c.getSchemas())
+                .map(s -> s.get(extractGroup(ref, CLASS_NAME_PATTERN)))
+                .orElse(null);
+        return schema == null ? Set.of() : inheritedPropertyKeys(schema, openAPI);
+    }
+
+    private Set<String> inheritedPropertyKeys(Schema<?> schema, OpenAPI openAPI) {
+        Set<String> keys = new HashSet<>();
+        Schema<?> ownSchema = schema;
+        if (schema instanceof ComposedSchema && schema.getOneOf() == null && schema.getAllOf() != null) {
+            for (Schema<?> s : schema.getAllOf()) {
+                if (s.get$ref() != null) {
+                    keys.addAll(inheritedPropertyKeys(s.get$ref(), openAPI));
+                } else {
+                    ownSchema = s;
+                }
+            }
+        }
+        if (ownSchema.getProperties() != null) {
+            keys.addAll(ownSchema.getProperties().keySet());
+        }
+        return keys;
+    }
+
+    private TypeSpec getDTOClass(String name, Schema<?> schema, OpenAPI openAPI, ClassName baseClass,
+                                 Set<String> inheritedKeys) {
         TypeSpec.Builder classBuilder;
         if (schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
             classBuilder = TypeSpec.interfaceBuilder(name);
@@ -278,36 +322,19 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
         Map<String, Schema> schemaMap = schema.getProperties();
         if (schemaMap != null) {
             //Add properties
+            String discriminatorProperty = schema.getDiscriminator() == null
+                    ? null : schema.getDiscriminator().getPropertyName();
             for (Map.Entry<String, Schema> entry : schemaMap.entrySet()) {
                 checkPropertyName(name, entry.getKey());
-                if (schema.getDiscriminator() != null
-                        && entry.getKey().equals(schema.getDiscriminator().getPropertyName())) {
-                    //Skip the descriminator property
+                // Skip the discriminator property, and any property already declared
+                // by an allOf ancestor (re-declaring the latter would make Lombok emit
+                // a clashing getter/setter that does not compile; the inherited field
+                // and accessors are reused instead).
+                if (entry.getKey().equals(discriminatorProperty)
+                        || inheritedKeys.contains(entry.getKey())) {
                     continue;
                 }
-                TypeName typeName = defineJavaType(entry.getValue(), openAPI, classBuilder,
-                        CaseUtils.snakeToCamel(entry.getKey(), true));
-
-                String propertyName =
-                        params.isForceSnakeCaseForProperties()
-                                ? CaseUtils.snakeToCamel(entry.getKey())
-                                : entry.getKey();
-
-                FieldSpec.Builder fieldBuilder = FieldSpec.builder(
-                        typeName,
-                        propertyName, Modifier.PRIVATE);
-                if (typeName instanceof ClassName && "ZonedDateTime"
-                        .equals(((ClassName) typeName).simpleName())) {
-                    fieldBuilder.addAnnotation(AnnotationSpec.builder(
-                                            ClassName.get(JsonDeserialize.class))
-                                    .addMember("using", "ZonedDateTimeDeserializer.class").build())
-                            .addAnnotation(AnnotationSpec.builder(
-                                            ClassName.get(JsonSerialize.class))
-                                    .addMember("using", "ZonedDateTimeSerializer.class").build());
-                    ensureJsonZonedDateTimeDeserializer();
-                }
-                FieldSpec fieldSpec = fieldBuilder.build();
-                classBuilder.addField(fieldSpec);
+                addPropertyField(entry.getKey(), entry.getValue(), openAPI, classBuilder);
             }
         }
 
@@ -335,6 +362,32 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
             classBuilder.addField(fieldSpec);
         }
         return classBuilder.build();
+    }
+
+    private void addPropertyField(String key, Schema<?> value, OpenAPI openAPI,
+                                  TypeSpec.Builder classBuilder) {
+        TypeName typeName = defineJavaType(value, openAPI, classBuilder,
+                CaseUtils.snakeToCamel(key, true));
+
+        String propertyName =
+                params.isForceSnakeCaseForProperties()
+                        ? CaseUtils.snakeToCamel(key)
+                        : key;
+
+        FieldSpec.Builder fieldBuilder = FieldSpec.builder(
+                typeName,
+                propertyName, Modifier.PRIVATE);
+        if (typeName instanceof ClassName && "ZonedDateTime"
+                .equals(((ClassName) typeName).simpleName())) {
+            fieldBuilder.addAnnotation(AnnotationSpec.builder(
+                                    ClassName.get(JsonDeserialize.class))
+                            .addMember("using", "ZonedDateTimeDeserializer.class").build())
+                    .addAnnotation(AnnotationSpec.builder(
+                                    ClassName.get(JsonSerialize.class))
+                            .addMember("using", "ZonedDateTimeSerializer.class").build());
+            ensureJsonZonedDateTimeDeserializer();
+        }
+        classBuilder.addField(fieldBuilder.build());
     }
 
     private void oneOfToInterface(Schema<?> schema, OpenAPI openAPI, TypeSpec.Builder classBuilder) {

--- a/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
@@ -53,7 +53,7 @@ class KotlinAPIExtractor(
             .forEach { paramSpec: RequestPartParams ->
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
-                        paramSpec.name,
+                        CaseUtils.toIdentifier(paramSpec.name),
                         paramSpec.typeName
                     ).addAnnotation(paramSpec.annotation).build()
                 )
@@ -69,7 +69,7 @@ class KotlinAPIExtractor(
             .forEach { parameter: Parameter ->
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
-                        CaseUtils.snakeToCamel(parameter.name),
+                        CaseUtils.toIdentifier(CaseUtils.snakeToCamel(parameter.name)),
                         typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
                     )
                         .addAnnotation(
@@ -94,7 +94,7 @@ class KotlinAPIExtractor(
                 val annotationSpec = builder.build()
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
-                        CaseUtils.snakeToCamel(parameter.name),
+                        CaseUtils.toIdentifier(CaseUtils.snakeToCamel(parameter.name)),
                         typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
                     )
                         .addAnnotation(
@@ -112,7 +112,7 @@ class KotlinAPIExtractor(
             .forEach { parameter: Parameter ->
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
-                        CaseUtils.kebabToCamel(parameter.name),
+                        CaseUtils.toIdentifier(CaseUtils.kebabToCamel(parameter.name)),
                         typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
                     )
                         .addAnnotation(

--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -211,11 +211,23 @@ class KotlinTypeDefiner internal constructor(
 
     private fun constructorPropertiesOf(schema: Schema<*>, openAPI: OpenAPI): List<InheritedProperty> {
         val result = mutableListOf<InheritedProperty>()
+        // A property can be re-declared at several levels of an allOf chain (the
+        // YouTrack spec, for example, restates inherited fields on every subtype).
+        // Keep only the first (most-base) declaration by key so the generated
+        // constructor does not carry duplicate parameters. First-wins also keeps
+        // the parameter order aligned with the base-class constructor, which is
+        // what a subclass forwards its super-constructor arguments to.
+        val seen = mutableSetOf<String>()
+        fun add(property: InheritedProperty) {
+            if (seen.add(property.key)) {
+                result.add(property)
+            }
+        }
         var ownSchema: Schema<*> = schema
         if (schema is ComposedSchema && schema.oneOf == null && schema.allOf != null) {
             for (s in schema.allOf) {
                 if (s.`$ref` != null) {
-                    result.addAll(constructorPropertiesOf(s.`$ref`, openAPI))
+                    constructorPropertiesOf(s.`$ref`, openAPI).forEach(::add)
                 } else {
                     ownSchema = s
                 }
@@ -225,7 +237,7 @@ class KotlinTypeDefiner internal constructor(
         val required = ownSchema.required?.toSet() ?: emptySet()
         ownSchema.properties?.forEach { (key, value) ->
             if (key != discriminatorProperty) {
-                result.add(InheritedProperty(key, value, required.contains(key)))
+                add(InheritedProperty(key, value, required.contains(key)))
             }
         }
         return result
@@ -341,9 +353,16 @@ class KotlinTypeDefiner internal constructor(
                 classBuilder.addSuperclassConstructorParameter("%N", propertyName)
             }
 
+            val inheritedKeys = inheritedProperties.mapTo(mutableSetOf()) { it.key }
             if (schemaMap != null) for ((key, value) in schemaMap) {
                 if (schema.discriminator != null && key == schema.discriminator.propertyName) {
                     //Skip the descriminator property
+                    continue
+                }
+                if (key in inheritedKeys) {
+                    //Already re-declared above as an `override` inherited from the
+                    //base class and forwarded to its constructor. Restating it here
+                    //as an own property would produce a duplicate declaration.
                     continue
                 }
                 addConstructorProperty(

--- a/src/test/java/ru/curs/hurdygurdy/CaseUtilsTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CaseUtilsTest.java
@@ -15,6 +15,24 @@ class CaseUtilsTest {
     }
 
     @Test
+    void toIdentifierNull() {
+        assertThat(CaseUtils.toIdentifier(null)).isNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "files[0],files0",       // multipart field with array brackets
+            "plain,plain",           // already legal — no-op
+            "a.b/c,abc",             // dotted / slashed name
+            "'',_",                  // empty becomes _
+            "'[]',_",                // only illegal chars becomes _
+            "0abc,_0abc",            // leading digit gets prefixed
+    })
+    void toIdentifier(String input, String expected) {
+        assertThat(CaseUtils.toIdentifier(input)).isEqualTo(expected);
+    }
+
+    @Test
     void snakeToCamelNull() {
         assertThat(CaseUtils.snakeToCamel(null)).isNull();
     }

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.inheritedRootProperty.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.inheritedRootProperty.approved.txt
@@ -1,0 +1,58 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/A.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = B.class, name = "b"),
+    @JsonSubTypes.Type(value = C.class, name = "c")})
+public class A {
+  private String description;
+}
+---
+/com/example/dto/B.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class B extends A {
+  private String oneMore;
+}
+---
+/com/example/dto/C.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class C extends A {
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -117,6 +117,30 @@ class CodegenTest {
         verify(result);
     }
 
+    @Test
+    void inheritedRootProperty() throws IOException {
+        // The maintainer's example from PR #233: a root-class property (`description`)
+        // inherited by children, including an otherwise-empty leaf (`C`).
+        codegen.generate(Path.of("src/test/resources/pr233_inheritance.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void youtrackOpenapiCompiles() throws IOException {
+        // Real-world regression: the YouTrack OpenAPI spec redeclares inherited
+        // properties (often with a narrower type) across deep allOf chains, which
+        // previously made Lombok emit clashing/uncompilable getters and setters, and
+        // has a multipart parameter literally named "files[0]" that is not a legal
+        // identifier. Properties are camelCase, so the snake-case check is disabled.
+        // Compile-only: no snapshot for 200+ files.
+        JavaCodegen jc = new JavaCodegen(GeneratorParams
+                .rootPackage("org.youtrack")
+                .generateResponseParameter(true)
+                .forceSnakeCaseForProperties(false));
+        jc.generate(Path.of("src/test/resources/youtrack_openapi.json"), result);
+        GeneratedCodeCompiler.assertJavaCompiles(result);
+    }
+
     /**
      * Verifies the generated output against its snapshot and additionally
      * verifies that the generated Java code compiles.

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.inheritedRootProperty.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.inheritedRootProperty.approved.txt
@@ -1,0 +1,56 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/A.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "type",
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(value = B::class, name = "b"),
+  JsonSubTypes.Type(value = C::class, name = "c"),
+)
+public sealed class A(
+  public open val description: String? = null,
+)
+---
+/com/example/dto/B.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class B(
+  override val description: String? = null,
+  public val oneMore: String? = null,
+) : A(description)
+---
+/com/example/dto/C.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class C(
+  override val description: String? = null,
+) : A(description)

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -141,6 +141,31 @@ class KCodegenTest {
         verify(result);
     }
 
+    @Test
+    void inheritedRootProperty() throws IOException {
+        // The maintainer's example from PR #233: a root-class property (`description`)
+        // inherited by children, including an otherwise-empty leaf (`C`). Before the
+        // fix `C` was generated as an `object` and `description` was not overridden,
+        // producing non-compiling code.
+        codegen.generate(Path.of("src/test/resources/pr233_inheritance.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void youtrackOpenapiCompiles() throws IOException {
+        // Real-world regression: the YouTrack OpenAPI spec has deep, property-
+        // redeclaring inheritance chains (e.g. ActivityItem -> MultiValueActivityItem
+        // -> WorkItemTypeActivityItem) that previously produced duplicate constructor
+        // properties and non-compiling code. Its properties are camelCase, so the
+        // snake-case check is disabled. Compile-only: no snapshot for 200+ files.
+        KotlinCodegen kc = new KotlinCodegen(GeneratorParams
+                .rootPackage("org.youtrack")
+                .generateResponseParameter(true)
+                .forceSnakeCaseForProperties(false));
+        kc.generate(Path.of("src/test/resources/youtrack_openapi.json"), result);
+        GeneratedCodeCompiler.assertKotlinCompiles(result);
+    }
+
 
     /**
      * Verifies the generated output against its snapshot and additionally

--- a/src/test/resources/pr233_inheritance.yaml
+++ b/src/test/resources/pr233_inheritance.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+  title: "PR233 inheritance example"
+  description: |
+    The exact schema the maintainer posted on
+    https://github.com/CourseOrchestra/hurdy-gurdy/pull/233 to show that a root
+    class property inherited by an otherwise-empty leaf produced non-compiling
+    Kotlin (leaf generated as `object`, inherited property not overridden).
+  version: "0.1"
+paths:
+components:
+  schemas:
+    A:
+      description: A
+      properties:
+        type:
+          type: string
+        description:
+          type: string
+          nullable: false
+      discriminator:
+        propertyName: type
+        mapping:
+          'b': '#/components/schemas/B'
+          'c': '#/components/schemas/C'
+    B:
+      description: B
+      allOf:
+        - $ref: "#/components/schemas/A"
+      properties:
+        one_more:
+          type: string
+    C:
+      description: C
+      allOf:
+        - $ref: "#/components/schemas/A"

--- a/src/test/resources/youtrack_openapi.json
+++ b/src/test/resources/youtrack_openapi.json
@@ -1,0 +1,19103 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "YouTrack REST API",
+    "description" : "YouTrack issue tracking and project management system",
+    "license" : {
+      "name" : "YouTrack license",
+      "url" : "https://www.jetbrains.com/youtrack/buy/license.html"
+    },
+    "version" : "2026.3"
+  },
+  "servers" : [ {
+    "url" : "https://youtrack.jetbrains.com:443/api"
+  } ],
+  "security" : [ {
+    "permanentToken" : [ ]
+  } ],
+  "paths" : {
+    "/activities" : {
+      "description" : "This resource provides access to the activities with the possibility to filter them by various parameters.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "categories",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "reverse",
+          "in" : "query",
+          "description" : "Indicates whether the order of returning activities is from newest to oldest or the opposite.\nIf `false`, then the oldest activity item that matches a selected filter is returned first.\nIf `true`, then the newest activity is returned first. By default, `false`.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "start",
+          "in" : "query",
+          "description" : "The timestamp in milliseconds indicating the start of the time interval the activity timestamp belongs to. \nStored as a unix timestamp at UTC. \nIf the parameter is not set, it is considered to be 0.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "end",
+          "in" : "query",
+          "description" : "The timestamp in milliseconds indicating the end of the time interval the activity timestamp belongs to. \nStored as a unix timestamp at UTC. \nIf the parameter is not set, it is considered as `Long.MAX_VALUE`.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "author",
+          "in" : "query",
+          "description" : "Parameter to filter activities by the author. You can specify one of the following parameters: the database ID, login, Hub ID,\nor `me` for the currently logged in user.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueQuery",
+          "in" : "query",
+          "description" : "Issue search query. For details about search syntax, refer to the <a href=\"https://www.jetbrains.com/help/youtrack/cloud/search-and-command-attributes.html\">YouTrack documentation</a>.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp",
+            "default" : "$type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of ActivityItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ActivityItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/{id}" : {
+      "description" : "This resource provides access to the activities with the possibility to filter them by various parameters.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp",
+            "default" : "$type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ActivityItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActivityItem"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/activitiesPage" : {
+      "description" : "This resource provides access to issue-related activity that is wrapped inside a page object.\nThe main advantage of the page in comparison to a list of activities is cursors.\nThe page provides boundary marks that supports iteration over the activities from the place\nthe page is finished.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "categories",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "reverse",
+          "in" : "query",
+          "description" : "Indicates whether the order of returning activities is from newest to oldest or the opposite.\nIf `false`, then the oldest activity item that matches a selected filter is returned first.\nIf `true`, then the newest activity is returned first. By default, `false`.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "start",
+          "in" : "query",
+          "description" : "The timestamp in milliseconds indicating the start of the time interval the activity timestamp belongs to. \nStored as a unix timestamp at UTC. \nIf the parameter is not set, it is considered to be 0.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "end",
+          "in" : "query",
+          "description" : "The timestamp in milliseconds indicating the end of the time interval the activity timestamp belongs to. \nStored as a unix timestamp at UTC. \nIf the parameter is not set, it is considered as `Long.MAX_VALUE`.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "author",
+          "in" : "query",
+          "description" : "Parameter to filter activities by the author. You can specify one of the following parameters: the database ID, login, Hub ID,\nor `me` for the currently logged in user.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueQuery",
+          "in" : "query",
+          "description" : "Issue search query. For details about search syntax, refer to the <a href=\"https://www.jetbrains.com/help/youtrack/cloud/search-and-command-attributes.html\">YouTrack documentation</a>.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "cursor",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "activityId",
+          "in" : "query",
+          "description" : "ID of the activity that should be included in the page. The activity is allocated to the middle of the page.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,activities($type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp),afterCursor,beforeCursor,hasAfter,hasBefore,id",
+            "default" : "$type,activities($type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp),afterCursor,beforeCursor,hasAfter,hasBefore,id"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ActivityCursorPage",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActivityCursorPage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/build" : {
+      "description" : "This resource provides operations with sets of builds.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of BuildBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/BuildBundle"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BuildBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single BuildBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BuildBundle"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/build/{id}" : {
+      "description" : "This resource provides operations with sets of builds.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single BuildBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BuildBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BuildBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single BuildBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BuildBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/build/{id}/values" : {
+      "description" : "This resource lets you work with the values in a specific set of builds (build bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,assembleDate,color($type,background,foreground,id),id,name,ordinal",
+            "default" : "$type,assembleDate,color($type,background,foreground,id),id,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of BuildBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/BuildBundleElement"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,assembleDate,color($type,background,foreground,id),id,name,ordinal",
+            "default" : "$type,assembleDate,color($type,background,foreground,id),id,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BuildBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single BuildBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BuildBundleElement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/build/{id}/values/{buildBundleElementId}" : {
+      "description" : "This resource lets you work with the values in a specific set of builds (build bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,assembleDate,color($type,background,foreground,id),id,name,ordinal",
+            "default" : "$type,assembleDate,color($type,background,foreground,id),id,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "buildBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single BuildBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BuildBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,assembleDate,color($type,background,foreground,id),id,name,ordinal",
+            "default" : "$type,assembleDate,color($type,background,foreground,id),id,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "buildBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BuildBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single BuildBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BuildBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "buildBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "buildBundleElementId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/enum" : {
+      "description" : "This resource lets you work with a set of values of the `enum` type.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of EnumBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/EnumBundle"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/EnumBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single EnumBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnumBundle"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/enum/{id}" : {
+      "description" : "This resource lets you work with a set of values of the `enum` type.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single EnumBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnumBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/EnumBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single EnumBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnumBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/enum/{id}/values" : {
+      "description" : "This resource lets you work with the values in a specific set of enumerated values (enum bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,localizedName,name,ordinal",
+            "default" : "$type,color($type,background,foreground,id),id,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of EnumBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/EnumBundleElement"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,localizedName,name,ordinal",
+            "default" : "$type,color($type,background,foreground,id),id,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/EnumBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single EnumBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnumBundleElement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/enum/{id}/values/{enumBundleElementId}" : {
+      "description" : "This resource lets you work with the values in a specific set of enumerated values (enum bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,localizedName,name,ordinal",
+            "default" : "$type,color($type,background,foreground,id),id,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "enumBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single EnumBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnumBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,localizedName,name,ordinal",
+            "default" : "$type,color($type,background,foreground,id),id,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "enumBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/EnumBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single EnumBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnumBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "enumBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "enumBundleElementId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/ownedField" : {
+      "description" : "This resource provides operations with owned field bundles.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of OwnedBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/OwnedBundle"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OwnedBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single OwnedBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OwnedBundle"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/ownedField/{id}" : {
+      "description" : "This resource provides operations with owned field bundles.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single OwnedBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OwnedBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OwnedBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single OwnedBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OwnedBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/ownedField/{id}/values" : {
+      "description" : "This resource lets you work with the values in a specific set of owned values (owned bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,name,ordinal,owner($type,id,login,ringId)",
+            "default" : "$type,color($type,background,foreground,id),id,name,ordinal,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of OwnedBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/OwnedBundleElement"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,name,ordinal,owner($type,id,login,ringId)",
+            "default" : "$type,color($type,background,foreground,id),id,name,ordinal,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OwnedBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single OwnedBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OwnedBundleElement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/ownedField/{id}/values/{ownedBundleElementId}" : {
+      "description" : "This resource lets you work with the values in a specific set of owned values (owned bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,name,ordinal,owner($type,id,login,ringId)",
+            "default" : "$type,color($type,background,foreground,id),id,name,ordinal,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "ownedBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single OwnedBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OwnedBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,name,ordinal,owner($type,id,login,ringId)",
+            "default" : "$type,color($type,background,foreground,id),id,name,ordinal,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "ownedBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OwnedBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single OwnedBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OwnedBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "ownedBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "ownedBundleElementId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/state" : {
+      "description" : "This resource provides operations with sets of values of the `state` type.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of StateBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/StateBundle"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/StateBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single StateBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StateBundle"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/state/{id}" : {
+      "description" : "This resource provides operations with sets of values of the `state` type.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single StateBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StateBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/StateBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single StateBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StateBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/state/{id}/values" : {
+      "description" : "This resource lets you work with the values in a specific set of states (state bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,isResolved,localizedName,name,ordinal",
+            "default" : "$type,color($type,background,foreground,id),id,isResolved,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of StateBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/StateBundleElement"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,isResolved,localizedName,name,ordinal",
+            "default" : "$type,color($type,background,foreground,id),id,isResolved,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/StateBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single StateBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StateBundleElement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/state/{id}/values/{stateBundleElementId}" : {
+      "description" : "This resource lets you work with the values in a specific set of states (state bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,isResolved,localizedName,name,ordinal",
+            "default" : "$type,color($type,background,foreground,id),id,isResolved,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "stateBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single StateBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StateBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,color($type,background,foreground,id),id,isResolved,localizedName,name,ordinal",
+            "default" : "$type,color($type,background,foreground,id),id,isResolved,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "stateBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/StateBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single StateBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StateBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "stateBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "stateBundleElementId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/user" : {
+      "description" : "This resource lets you work with the sets of users in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of UserBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserBundle"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single UserBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserBundle"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/user/{id}" : {
+      "description" : "This resource lets you work with the sets of users in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single UserBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single UserBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/user/{id}/aggregatedUsers" : {
+      "description" : "This resource lets you read the list of all users that the specific bundle contains, both that were added as members of groups and individually.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/user/{id}/aggregatedUsers/{userId}" : {
+      "description" : "This resource lets you read the list of all users that the specific bundle contains, both that were added as members of groups and individually.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "userId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/user/{id}/groups" : {
+      "description" : "This resource lets you work with the user groups that are added to the specific set of users.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserGroup"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserGroup"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/user/{id}/groups/{userGroupId}" : {
+      "description" : "This resource lets you work with the user groups that are added to the specific set of users.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userGroupId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserGroup"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userGroupId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "userGroupId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/user/{id}/individuals" : {
+      "description" : "This resource lets you work with the user accounts that were added individually to a specific set of users (user bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/user/{id}/individuals/{userId}" : {
+      "description" : "This resource lets you work with the user accounts that were added individually to a specific set of users (user bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "userId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/version" : {
+      "description" : "This resource provides operations with version bundles. Version bundles are used as the set of allowed values for custom fields of the `version` type.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of VersionBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/VersionBundle"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VersionBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single VersionBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VersionBundle"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/version/{id}" : {
+      "description" : "This resource provides operations with version bundles. Version bundles are used as the set of allowed values for custom fields of the `version` type.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single VersionBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VersionBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VersionBundle"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single VersionBundle",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VersionBundle"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/bundles/version/{id}/values" : {
+      "description" : "This resource lets you work with the version values in a specific set of versions (version bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,color($type,background,foreground,id),id,name,ordinal,releaseDate,released",
+            "default" : "$type,archived,color($type,background,foreground,id),id,name,ordinal,releaseDate,released"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of VersionBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/VersionBundleElement"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,color($type,background,foreground,id),id,name,ordinal,releaseDate,released",
+            "default" : "$type,archived,color($type,background,foreground,id),id,name,ordinal,releaseDate,released"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VersionBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single VersionBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VersionBundleElement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/bundles/version/{id}/values/{versionBundleElementId}" : {
+      "description" : "This resource lets you work with the version values in a specific set of versions (version bundle).",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,color($type,background,foreground,id),id,name,ordinal,releaseDate,released",
+            "default" : "$type,archived,color($type,background,foreground,id),id,name,ordinal,releaseDate,released"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "versionBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single VersionBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VersionBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,color($type,background,foreground,id),id,name,ordinal,releaseDate,released",
+            "default" : "$type,archived,color($type,background,foreground,id),id,name,ordinal,releaseDate,released"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "versionBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VersionBundleElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single VersionBundleElement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VersionBundleElement"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "versionBundleElementId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "versionBundleElementId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/customFields" : {
+      "description" : "This resource lets you work with the custom fields. In the old REST API we called them \"prototypes\".",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,fieldType($type,id),id,isAutoAttached,isUpdateable,localizedName,name,ordinal",
+            "default" : "$type,fieldType($type,id),id,isAutoAttached,isUpdateable,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of CustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/CustomField"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,fieldType($type,id),id,isAutoAttached,isUpdateable,localizedName,name,ordinal",
+            "default" : "$type,fieldType($type,id),id,isAutoAttached,isUpdateable,localizedName,name,ordinal"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CustomField"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single CustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CustomField"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/customFields/{id}" : {
+      "description" : "This resource lets you work with the custom fields. In the old REST API we called them \"prototypes\".",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,fieldType($type,id),id,isAutoAttached,isUpdateable,localizedName,name,ordinal",
+            "default" : "$type,fieldType($type,id),id,isAutoAttached,isUpdateable,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single CustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CustomField"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,fieldType($type,id),id,isAutoAttached,isUpdateable,localizedName,name,ordinal",
+            "default" : "$type,fieldType($type,id),id,isAutoAttached,isUpdateable,localizedName,name,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CustomField"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single CustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CustomField"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/customFields/{id}/fieldDefaults" : {
+      "description" : "This resource lets you read and update default settings of a custom field in a project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,id,isPublic",
+            "default" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,id,isPublic"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single CustomFieldDefaults",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CustomFieldDefaults"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,id,isPublic",
+            "default" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,id,isPublic"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CustomFieldDefaults"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single CustomFieldDefaults",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CustomFieldDefaults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/customFields/{id}/instances" : {
+      "description" : "This resource lets you read a so called instances of the custom fields - settings of the custom field in each project that uses it.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal",
+            "default" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of ProjectCustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ProjectCustomField"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/customFields/{id}/instances/{projectCustomFieldId}" : {
+      "description" : "This resource lets you read a so called instances of the custom fields - settings of the custom field in each project that uses it.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "projectCustomFieldId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/customFieldSettings/types" : {
+      "description" : "This resource lets you read the list of supported types of custom fields in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of FieldType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/FieldType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/customFieldSettings/types/{id}" : {
+      "description" : "This resource lets you read the list of supported types of custom fields in YouTrack.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/databaseBackup/backups" : {
+      "description" : "This resource lets you access the database backup files. The user account that performs the operation\nmust have <emphasis>Low-level Read Administration</emphasis> permissions.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,creationDate,id,link,name,size",
+            "default" : "$type,creationDate,id,link,name,size"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of BackupFile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/BackupFile"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/databaseBackup/backups/{id}" : {
+      "description" : "This resource lets you access the database backup files. The user account that performs the operation\nmust have <emphasis>Low-level Read Administration</emphasis> permissions.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,creationDate,id,link,name,size",
+            "default" : "$type,creationDate,id,link,name,size"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single BackupFile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BackupFile"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/databaseBackup/settings" : {
+      "description" : "This resource lets you configure settings of the database backup.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,availableDiskSpace,backupStatus($type,backupCancelled,backupError($type,date,errorMessage,id),backupInProgress,id),id,isOn,location",
+            "default" : "$type,availableDiskSpace,backupStatus($type,backupCancelled,backupError($type,date,errorMessage,id),backupInProgress,id),id,isOn,location"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single DatabaseBackupSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DatabaseBackupSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,availableDiskSpace,backupStatus($type,backupCancelled,backupError($type,date,errorMessage,id),backupInProgress,id),id,isOn,location",
+            "default" : "$type,availableDiskSpace,backupStatus($type,backupCancelled,backupError($type,date,errorMessage,id),backupInProgress,id),id,isOn,location"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DatabaseBackupSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single DatabaseBackupSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DatabaseBackupSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/databaseBackup/settings/backupStatus" : {
+      "description" : "This resource lets you get the status of the back up process.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,backupCancelled,backupError($type,date,errorMessage,id),backupInProgress,id",
+            "default" : "$type,backupCancelled,backupError($type,date,errorMessage,id),backupInProgress,id"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single BackupStatus",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BackupStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/globalSettings" : {
+      "description" : "Provides operations with global application settings.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,appearanceSettings($type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,timeZone($type,id,offset,presentation)),id,license($type,error,id,license,username),localeSettings($type,id,isRTL,locale($type,community,id,language,locale,name)),notificationSettings($type,emailSettings($type,id,isEnabled),id),restSettings($type,allowAllOrigins,allowedOrigins,id),systemSettings($type,baseUrl,id,isApplicationReadOnly,maxExportItems,maxUploadFileSize)",
+            "default" : "$type,appearanceSettings($type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,timeZone($type,id,offset,presentation)),id,license($type,error,id,license,username),localeSettings($type,id,isRTL,locale($type,community,id,language,locale,name)),notificationSettings($type,emailSettings($type,id,isEnabled),id),restSettings($type,allowAllOrigins,allowedOrigins,id),systemSettings($type,baseUrl,id,isApplicationReadOnly,maxExportItems,maxUploadFileSize)"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single GlobalSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GlobalSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,appearanceSettings($type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,timeZone($type,id,offset,presentation)),id,license($type,error,id,license,username),localeSettings($type,id,isRTL,locale($type,community,id,language,locale,name)),notificationSettings($type,emailSettings($type,id,isEnabled),id),restSettings($type,allowAllOrigins,allowedOrigins,id),systemSettings($type,baseUrl,id,isApplicationReadOnly,maxExportItems,maxUploadFileSize)",
+            "default" : "$type,appearanceSettings($type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,timeZone($type,id,offset,presentation)),id,license($type,error,id,license,username),localeSettings($type,id,isRTL,locale($type,community,id,language,locale,name)),notificationSettings($type,emailSettings($type,id,isEnabled),id),restSettings($type,allowAllOrigins,allowedOrigins,id),systemSettings($type,baseUrl,id,isApplicationReadOnly,maxExportItems,maxUploadFileSize)"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/GlobalSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single GlobalSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GlobalSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/globalSettings/appearanceSettings" : {
+      "description" : "This resource lets you work with the Visual settings of your YouTrack service.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,timeZone($type,id,offset,presentation)",
+            "default" : "$type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,timeZone($type,id,offset,presentation)"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single AppearanceSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppearanceSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,timeZone($type,id,offset,presentation)",
+            "default" : "$type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,timeZone($type,id,offset,presentation)"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AppearanceSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single AppearanceSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppearanceSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/globalSettings/license" : {
+      "description" : "This resource lets you work with the license of your YouTrack service.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,error,id,license,username",
+            "default" : "$type,error,id,license,username"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single License",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/License"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,error,id,license,username",
+            "default" : "$type,error,id,license,username"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/License"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single License",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/License"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/globalSettings/localeSettings" : {
+      "description" : "This resource lets you work with the system language settings of your YouTrack service.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,isRTL,locale($type,community,id,language,locale,name)",
+            "default" : "$type,id,isRTL,locale($type,community,id,language,locale,name)"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single LocaleSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LocaleSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,isRTL,locale($type,community,id,language,locale,name)",
+            "default" : "$type,id,isRTL,locale($type,community,id,language,locale,name)"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LocaleSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single LocaleSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LocaleSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/globalSettings/notificationSettings" : {
+      "description" : "This resource lets you work with the notification settings of your YouTrack service: read and configure Email server settings to enable notifications to users.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,emailSettings($type,id,isEnabled),id",
+            "default" : "$type,emailSettings($type,id,isEnabled),id"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single NotificationSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NotificationSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,emailSettings($type,id,isEnabled),id",
+            "default" : "$type,emailSettings($type,id,isEnabled),id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NotificationSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single NotificationSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NotificationSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/globalSettings/restSettings" : {
+      "description" : "This resource lets you work with the Resource Sharing settings of your YouTrack service.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allowAllOrigins,allowedOrigins,id",
+            "default" : "$type,allowAllOrigins,allowedOrigins,id"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single RestCorsSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RestCorsSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allowAllOrigins,allowedOrigins,id",
+            "default" : "$type,allowAllOrigins,allowedOrigins,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/RestCorsSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single RestCorsSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RestCorsSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/globalSettings/systemSettings" : {
+      "description" : "This resource lets you work with the System settings of your YouTrack service.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,baseUrl,id,isApplicationReadOnly,maxExportItems,maxUploadFileSize",
+            "default" : "$type,baseUrl,id,isApplicationReadOnly,maxExportItems,maxUploadFileSize"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single SystemSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SystemSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,baseUrl,id,isApplicationReadOnly,maxExportItems,maxUploadFileSize",
+            "default" : "$type,baseUrl,id,isApplicationReadOnly,maxExportItems,maxUploadFileSize"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SystemSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single SystemSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SystemSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/organizations" : {
+      "description" : "This resource lets you work with organizations in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Organization",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Organization"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Organization"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Organization",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Organization"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/organizations/{id}" : {
+      "description" : "This resource lets you work with organizations in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Organization",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Organization"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Organization"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Organization",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Organization"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/projects" : {
+      "description" : "This resource provides access to projects.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName",
+            "default" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Project",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Project"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "template",
+          "in" : "query",
+          "description" : "If the `template` is not specified, then the new project will use the default settings.\n<emphasis>Optional</emphasis>. Lets you specify the template to use for the new project.\nPossible values: `scrum`, `kanban`.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName",
+            "default" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Project"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Project",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}" : {
+      "description" : "This resource provides access to projects.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName",
+            "default" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Project",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName",
+            "default" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Project"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Project",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/projects/{id}/articles" : {
+      "description" : "This resource lets you work with articles that belong to the project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Article"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/articles/{articleId}" : {
+      "description" : "This resource lets you work with articles that belong to the project.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "articleId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/projects/{id}/customFields" : {
+      "description" : "This resource lets you access and configure custom fields in the specific project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal",
+            "default" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of ProjectCustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ProjectCustomField"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal",
+            "default" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ProjectCustomField"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single ProjectCustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProjectCustomField"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/customFields/{projectCustomFieldId}" : {
+      "description" : "This resource lets you access and configure custom fields in the specific project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal",
+            "default" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "projectCustomFieldId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ProjectCustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProjectCustomField"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal",
+            "default" : "$type,bundle($type,id),canBeEmpty,defaultValues($type,id,name),emptyFieldText,field($type,fieldType($type,id),id,localizedName,name),id,isPublic,ordinal"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "projectCustomFieldId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ProjectCustomField"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single ProjectCustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProjectCustomField"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "projectCustomFieldId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "projectCustomFieldId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/projects/{id}/issues" : {
+      "description" : "This resource lets you work with issues within the particular project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "customFields",
+          "in" : "query",
+          "description" : "<p>The name of the custom field to show in the response. When you use this parameter and request the custom field data in the request URL, the response only shows the requested custom fields instead of all of them.</p><p>To show more than one custom field, use this parameter several times.</p><p>See Sample 2 for reference.</p>",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Issue"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Issue"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/issues/{issueId}" : {
+      "description" : "This resource lets you work with issues within the particular project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Issue"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Issue"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/projects/{id}/team" : {
+      "description" : "This resource lets you read and update the project team.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ProjectTeam",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProjectTeam"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ProjectTeam"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single ProjectTeam",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProjectTeam"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/team/groups" : {
+      "description" : "This resource lets you work with the groups added to the project team.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserGroup"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserGroup"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/team/groups/{userGroupId}" : {
+      "description" : "This resource lets you work with the groups added to the project team.",
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userGroupId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "userGroupId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/projects/{id}/team/ownUsers" : {
+      "description" : "This resource lets you work with the users added to the project team directly.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/team/ownUsers/{userId}" : {
+      "description" : "This resource lets you work with the users added to the project team directly.",
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "userId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/projects/{id}/team/users" : {
+      "description" : "This resource lets you read the users in the project team.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/team/users/{userId}" : {
+      "description" : "This resource lets you read the users in the project team.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "userId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/projects/{id}/timeTrackingSettings" : {
+      "description" : "This resource lets you configure the time tracking settings for the specific project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,enabled,estimate($type,field($type,fieldType($type,id),id,localizedName,name),id),id,timeSpent($type,field($type,fieldType($type,id),id,localizedName,name),id)",
+            "default" : "$type,enabled,estimate($type,field($type,fieldType($type,id),id,localizedName,name),id),id,timeSpent($type,field($type,fieldType($type,id),id,localizedName,name),id)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ProjectTimeTrackingSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProjectTimeTrackingSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,enabled,estimate($type,field($type,fieldType($type,id),id,localizedName,name),id),id,timeSpent($type,field($type,fieldType($type,id),id,localizedName,name),id)",
+            "default" : "$type,enabled,estimate($type,field($type,fieldType($type,id),id,localizedName,name),id),id,timeSpent($type,field($type,fieldType($type,id),id,localizedName,name),id)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ProjectTimeTrackingSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single ProjectTimeTrackingSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProjectTimeTrackingSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/timeTrackingSettings/workItemTypes" : {
+      "description" : "This resource lets you configure work item types of the project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,autoAttached,id,name",
+            "default" : "$type,autoAttached,id,name"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of WorkItemType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/WorkItemType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,autoAttached,id,name",
+            "default" : "$type,autoAttached,id,name"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/WorkItemType"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single WorkItemType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WorkItemType"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/projects/{id}/timeTrackingSettings/workItemTypes/{workItemTypeId}" : {
+      "description" : "This resource lets you configure work item types of the project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,autoAttached,id,name",
+            "default" : "$type,autoAttached,id,name"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "workItemTypeId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single WorkItemType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WorkItemType"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "workItemTypeId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "workItemTypeId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/telemetry" : {
+      "description" : "This resource lets you get telemetry data of your YouTrack service.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allocatedMemory,availableMemory,availableProcessors,blobStringsCacheHitRate,cachedResultsCountInDBQueriesCache,databaseBackgroundThreads,databaseLocation,databaseQueriesCacheHitRate,databaseSize,fullDatabaseSize,id,installationFolder,logsLocation,notificationAnalyzerThreads,onlineUsers($type,id,users),pendingAsyncJobs,reportCalculatorThreads,requestsPerSecond,startedTime,textIndexSize,totalTransactions,transactionsPerSecond,uptime,usedMemory",
+            "default" : "$type,allocatedMemory,availableMemory,availableProcessors,blobStringsCacheHitRate,cachedResultsCountInDBQueriesCache,databaseBackgroundThreads,databaseLocation,databaseQueriesCacheHitRate,databaseSize,fullDatabaseSize,id,installationFolder,logsLocation,notificationAnalyzerThreads,onlineUsers($type,id,users),pendingAsyncJobs,reportCalculatorThreads,requestsPerSecond,startedTime,textIndexSize,totalTransactions,transactionsPerSecond,uptime,usedMemory"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Telemetry",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Telemetry"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/timeTrackingSettings" : {
+      "description" : "This resource lets you configure system-wide time tracking settings.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,workItemTypes($type,id,name),workTimeSettings($type,daysAWeek,firstDayOfWeek,id,minutesADay,workDays)",
+            "default" : "$type,id,workItemTypes($type,id,name),workTimeSettings($type,daysAWeek,firstDayOfWeek,id,minutesADay,workDays)"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single GlobalTimeTrackingSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GlobalTimeTrackingSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/timeTrackingSettings/workItemTypes" : {
+      "description" : "This resource lets you read, update, and delete types of work items.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,autoAttached,id,name",
+            "default" : "$type,autoAttached,id,name"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of WorkItemType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/WorkItemType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,autoAttached,id,name",
+            "default" : "$type,autoAttached,id,name"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/WorkItemType"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single WorkItemType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WorkItemType"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/timeTrackingSettings/workItemTypes/{workItemTypeId}" : {
+      "description" : "This resource lets you read, update, and delete types of work items.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,autoAttached,id,name",
+            "default" : "$type,autoAttached,id,name"
+          }
+        }, {
+          "name" : "workItemTypeId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single WorkItemType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WorkItemType"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,autoAttached,id,name",
+            "default" : "$type,autoAttached,id,name"
+          }
+        }, {
+          "name" : "workItemTypeId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/WorkItemType"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single WorkItemType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WorkItemType"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "workItemTypeId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "workItemTypeId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/admin/timeTrackingSettings/workTimeSettings" : {
+      "description" : "This resource lets you configure the system-wide work time settings.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,daysAWeek,firstDayOfWeek,id,minutesADay,workDays",
+            "default" : "$type,daysAWeek,firstDayOfWeek,id,minutesADay,workDays"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single WorkTimeSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WorkTimeSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,daysAWeek,firstDayOfWeek,id,minutesADay,workDays",
+            "default" : "$type,daysAWeek,firstDayOfWeek,id,minutesADay,workDays"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/WorkTimeSettings"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single WorkTimeSettings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WorkTimeSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agiles" : {
+      "description" : "This resource lets you work with agile boards in YouTrack using the REST API.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,columnSettings($type,columns($type,id),field($type,fieldType($type,id),id,localizedName,name),id),id,name,owner($type,id,login,ringId),projects($type,id,name,shortName),status($type,id,valid),swimlaneSettings($type,enabled,field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,values($type,id,name))",
+            "default" : "$type,columnSettings($type,columns($type,id),field($type,fieldType($type,id),id,localizedName,name),id),id,name,owner($type,id,login,ringId),projects($type,id,name,shortName),status($type,id,valid),swimlaneSettings($type,enabled,field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,values($type,id,name))"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Agile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Agile"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "template",
+          "in" : "query",
+          "description" : "The name of the board template that should be used. Possible values: `kanban`, `scrum`, `version`, `custom`, `personal`.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,columnSettings($type,columns($type,id),field($type,fieldType($type,id),id,localizedName,name),id),id,name,owner($type,id,login,ringId),projects($type,id,name,shortName),status($type,id,valid),swimlaneSettings($type,enabled,field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,values($type,id,name))",
+            "default" : "$type,columnSettings($type,columns($type,id),field($type,fieldType($type,id),id,localizedName,name),id),id,name,owner($type,id,login,ringId),projects($type,id,name,shortName),status($type,id,valid),swimlaneSettings($type,enabled,field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,values($type,id,name))"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Agile"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Agile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Agile"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agiles/{id}" : {
+      "description" : "This resource lets you work with agile boards in YouTrack using the REST API.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,columnSettings($type,columns($type,id),field($type,fieldType($type,id),id,localizedName,name),id),id,name,owner($type,id,login,ringId),projects($type,id,name,shortName),status($type,id,valid),swimlaneSettings($type,enabled,field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,values($type,id,name))",
+            "default" : "$type,columnSettings($type,columns($type,id),field($type,fieldType($type,id),id,localizedName,name),id),id,name,owner($type,id,login,ringId),projects($type,id,name,shortName),status($type,id,valid),swimlaneSettings($type,enabled,field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,values($type,id,name))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Agile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Agile"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,columnSettings($type,columns($type,id),field($type,fieldType($type,id),id,localizedName,name),id),id,name,owner($type,id,login,ringId),projects($type,id,name,shortName),status($type,id,valid),swimlaneSettings($type,enabled,field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,values($type,id,name))",
+            "default" : "$type,columnSettings($type,columns($type,id),field($type,fieldType($type,id),id,localizedName,name),id),id,name,owner($type,id,login,ringId),projects($type,id,name,shortName),status($type,id,valid),swimlaneSettings($type,enabled,field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,values($type,id,name))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Agile"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Agile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Agile"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/agiles/{id}/sprints" : {
+      "description" : "This resource lets you work with sprints of the specific agile board.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,finish,id,isDefault,name,start",
+            "default" : "$type,archived,finish,id,isDefault,name,start"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Sprint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Sprint"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,finish,id,isDefault,name,start",
+            "default" : "$type,archived,finish,id,isDefault,name,start"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Sprint"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Sprint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Sprint"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agiles/{id}/sprints/{sprintId}" : {
+      "description" : "This resource lets you work with sprints of the specific agile board.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,finish,id,isDefault,name,start",
+            "default" : "$type,archived,finish,id,isDefault,name,start"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sprintId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Sprint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Sprint"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,finish,id,isDefault,name,start",
+            "default" : "$type,archived,finish,id,isDefault,name,start"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sprintId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Sprint"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Sprint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Sprint"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sprintId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "sprintId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/articles" : {
+      "description" : "This resource lets you access articles in the YouTrack knowledge base.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Article"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "draftId",
+          "in" : "query",
+          "description" : "ID of a draft to publish as a new article. If no `draftId` is provided, the article is created from scratch. In this case, you must specify the project in the request payload.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires Apply Commands Silently permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Article"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Article"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/articles/{id}" : {
+      "description" : "This resource lets you access articles in the YouTrack knowledge base.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Article"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires Apply Commands Silently permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Article"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Article"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/articles/{id}/attachments" : {
+      "description" : "This resource lets you work with attachments in a specific article.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url",
+            "default" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of ArticleAttachment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ArticleAttachment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url",
+            "default" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ArticleAttachment"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single ArticleAttachment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArticleAttachment"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/articles/{id}/attachments/{articleAttachmentId}" : {
+      "description" : "This resource lets you work with attachments in a specific article.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url",
+            "default" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleAttachmentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ArticleAttachment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArticleAttachment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url",
+            "default" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleAttachmentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ArticleAttachment"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single ArticleAttachment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArticleAttachment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleAttachmentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "articleAttachmentId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/articles/{id}/childArticles" : {
+      "description" : "This resource lets you work with the sub-articles of the current article.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Article"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires Apply Commands Silently permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Article"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Article"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/articles/{id}/childArticles/{articleId}" : {
+      "description" : "This resource lets you work with the sub-articles of the current article.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Article"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires Apply Commands Silently permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Article"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Article"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "articleId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/articles/{id}/comments" : {
+      "description" : "This resource lets you work with comments to an article.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,attachments($type,id),author($type,id,login,ringId),created,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,attachments($type,id),author($type,id,login,ringId),created,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of ArticleComment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ArticleComment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "draftId",
+          "in" : "query",
+          "description" : "The ID of an existing draft that should be published. This parameter is optional.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,attachments($type,id),author($type,id,login,ringId),created,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,attachments($type,id),author($type,id,login,ringId),created,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ArticleComment"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single ArticleComment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArticleComment"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/articles/{id}/comments/{articleCommentId}" : {
+      "description" : "This resource lets you work with comments to an article.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,attachments($type,id),author($type,id,login,ringId),created,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,attachments($type,id),author($type,id,login,ringId),created,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ArticleComment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArticleComment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,attachments($type,id),author($type,id,login,ringId),created,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,attachments($type,id),author($type,id,login,ringId),created,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ArticleComment"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single ArticleComment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArticleComment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "articleCommentId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/articles/{id}/comments/{articleCommentId}/reactions" : {
+      "description" : "This resource lets you work with reactions to an article comment.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Reaction",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Reaction"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Reaction"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Reaction",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Reaction"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/articles/{id}/comments/{articleCommentId}/reactions/{reactionId}" : {
+      "description" : "This resource lets you work with reactions to an article comment.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "reactionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Reaction",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Reaction"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "articleCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "reactionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "articleCommentId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "reactionId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/articles/{id}/parentArticle" : {
+      "description" : "This resource lets you get the parent article of the current one.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)",
+            "default" : "$type,content,created,id,idReadable,parentArticle($type,id,idReadable),project($type,id,name,shortName),summary,updated,updatedBy($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Article",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Article"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/articles/{id}/tags" : {
+      "description" : "This sub-resource lets you work with the tags that are added to the specific article.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Tag"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/articles/{id}/tags/{tagId}" : {
+      "description" : "This sub-resource lets you work with the tags that are added to the specific article.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "tagId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "tagId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "tagId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/assignedRoles" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "query",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of AssignedRole",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/AssignedRole"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/assignedRoles/{id}" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single AssignedRole",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AssignedRole"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AssignedRole"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single AssignedRole",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AssignedRole"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/commands" : {
+      "description" : "This resource lets you apply commands to issues.",
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,caret,commands($type,description,error,id),comment,id,issues($type,id,idReadable,numberInProject),query,suggestions($type,caret,completionEnd,completionStart,description,id,matchingEnd,matchingStart,option,prefix,suffix)",
+            "default" : "$type,caret,commands($type,description,error,id),comment,id,issues($type,id,idReadable,numberInProject),query,suggestions($type,caret,completionEnd,completionStart,description,id,matchingEnd,matchingStart,option,prefix,suffix)"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CommandList"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single CommandList",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CommandList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commands/assist" : {
+      "description" : "Lets you get suggestions for the currently entered command.",
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,caret,commands($type,description,error,id),comment,id,issues($type,id,idReadable,numberInProject),query,suggestions($type,caret,completionEnd,completionStart,description,id,matchingEnd,matchingStart,option,prefix,suffix)",
+            "default" : "$type,caret,commands($type,description,error,id),comment,id,issues($type,id,idReadable,numberInProject),query,suggestions($type,caret,completionEnd,completionStart,description,id,matchingEnd,matchingStart,option,prefix,suffix)"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CommandList"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single CommandList",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CommandList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "query",
+          "in" : "query",
+          "description" : "A search query.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserGroup"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserGroup"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{id}" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserGroup"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single UserGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserGroup"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/groups/{id}/ownUsers" : {
+      "description" : "This resource lets you work with the users added to the user group directly.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{id}/ownUsers/{userId}" : {
+      "description" : "This resource lets you work with the users added to the user group directly.",
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "userId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/groups/{id}/subGroups" : {
+      "description" : "The subgroups of the user group.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,allUsersGroup,id,name,ringId",
+            "default" : "$type,allUsersGroup,id,name,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of NestedGroup",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/NestedGroup"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{id}/subGroups/{nestedGroupId}" : {
+      "description" : "The subgroups of the user group.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "nestedGroupId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/groups/{id}/users" : {
+      "description" : "This resource lets you work with the users in the group.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/groups/{id}/users/{userId}" : {
+      "description" : "This resource lets you work with the users in the group.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "userId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issueLinkTypes" : {
+      "description" : "This resource provides operations with issue link types.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,aggregation,directed,id,localizedName,localizedSourceToTarget,localizedTargetToSource,name,readOnly,sourceToTarget,targetToSource",
+            "default" : "$type,aggregation,directed,id,localizedName,localizedSourceToTarget,localizedTargetToSource,name,readOnly,sourceToTarget,targetToSource"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of IssueLinkType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/IssueLinkType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,aggregation,directed,id,localizedName,localizedSourceToTarget,localizedTargetToSource,name,readOnly,sourceToTarget,targetToSource",
+            "default" : "$type,aggregation,directed,id,localizedName,localizedSourceToTarget,localizedTargetToSource,name,readOnly,sourceToTarget,targetToSource"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueLinkType"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueLinkType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueLinkType"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issueLinkTypes/{id}" : {
+      "description" : "This resource provides operations with issue link types.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,aggregation,directed,id,localizedName,localizedSourceToTarget,localizedTargetToSource,name,readOnly,sourceToTarget,targetToSource",
+            "default" : "$type,aggregation,directed,id,localizedName,localizedSourceToTarget,localizedTargetToSource,name,readOnly,sourceToTarget,targetToSource"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single IssueLinkType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueLinkType"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,aggregation,directed,id,localizedName,localizedSourceToTarget,localizedTargetToSource,name,readOnly,sourceToTarget,targetToSource",
+            "default" : "$type,aggregation,directed,id,localizedName,localizedSourceToTarget,localizedTargetToSource,name,readOnly,sourceToTarget,targetToSource"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueLinkType"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueLinkType",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueLinkType"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issueTags" : {
+      "description" : "<p>Deprecated. Use the <a href=\"resource-api-tags.topic\">Tags</a> resource instead.</p>"
+    },
+    "/issues" : {
+      "description" : "Resource that provides access to issues.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "query",
+          "in" : "query",
+          "description" : "Issue search query. Read more about the search syntax here: <a href=\"https://www.jetbrains.com/help/youtrack/cloud/?Search-and-Command-Attributes\">Search Query Reference</a>",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "customFields",
+          "in" : "query",
+          "description" : "<p>The name of the custom field to show in the response. When you use this parameter and request the custom field data in the request URL, the response only shows the requested custom fields instead of all of them.</p><p>To show more than one custom field, use this parameter several times.</p><p>See Sample 2 for reference.</p>",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Issue"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "draftId",
+          "in" : "query",
+          "description" : "ID of a draft to report as the new issue. If no `draftId` is provided, the issue is created from scratch. In this case, you must specify the summary and the project in the request payload.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Issue"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}" : {
+      "description" : "Resource that provides access to issues.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Issue"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Issue"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/activities" : {
+      "description" : "This resource lets you get the history of operations for a specific issue. It provides access to the issue activities with the possibility to filter them by various parameters.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "categories",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "reverse",
+          "in" : "query",
+          "description" : "Indicates whether the order of returning activities is from newest to oldest or the opposite.\nIf `false`, then the oldest activity item that matches a selected filter is returned first.\nIf `true`, then the newest activity is returned first. By default, `false`.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "start",
+          "in" : "query",
+          "description" : "The timestamp in milliseconds indicating the start of the time interval the activity timestamp belongs to. \nStored as a unix timestamp at UTC. \nIf the parameter is not set, it is considered to be 0.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "end",
+          "in" : "query",
+          "description" : "The timestamp in milliseconds indicating the end of the time interval the activity timestamp belongs to. \nStored as a unix timestamp at UTC. \nIf the parameter is not set, it is considered as `Long.MAX_VALUE`.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "author",
+          "in" : "query",
+          "description" : "Parameter to filter activities by the author. You can specify one of the following parameters: the database ID, login, Hub ID,\nor `me` for the currently logged in user.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp",
+            "default" : "$type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of ActivityItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ActivityItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/activities/{activityItemId}" : {
+      "description" : "This resource lets you get the history of operations for a specific issue. It provides access to the issue activities with the possibility to filter them by various parameters.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp",
+            "default" : "$type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "activityItemId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ActivityItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActivityItem"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "activityItemId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/activitiesPage" : {
+      "description" : "This resource provides access to the issue activities wrapping it to the page object.\nThe main advantage of the page in comparison to a list of activities is cursors.\nThe page provides boundary marks that allows continuing iteration over the activities from the place\nthe page is finished.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "categories",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "reverse",
+          "in" : "query",
+          "description" : "Indicates whether the order of returning activities is from newest to oldest or the opposite.\nIf `false`, then the oldest activity item that matches a selected filter is returned first.\nIf `true`, then the newest activity is returned first. By default, `false`.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "start",
+          "in" : "query",
+          "description" : "The timestamp in milliseconds indicating the start of the time interval the activity timestamp belongs to. \nStored as a unix timestamp at UTC. \nIf the parameter is not set, it is considered to be 0.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "end",
+          "in" : "query",
+          "description" : "The timestamp in milliseconds indicating the end of the time interval the activity timestamp belongs to. \nStored as a unix timestamp at UTC. \nIf the parameter is not set, it is considered as `Long.MAX_VALUE`.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "author",
+          "in" : "query",
+          "description" : "Parameter to filter activities by the author. You can specify one of the following parameters: the database ID, login, Hub ID,\nor `me` for the currently logged in user.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "cursor",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "activityId",
+          "in" : "query",
+          "description" : "ID of the activity that should be included in the page. The activity is allocated to the middle of the page.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,activities($type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp),afterCursor,beforeCursor,hasAfter,hasBefore,id",
+            "default" : "$type,activities($type,added,author($type,id,login,ringId),category($type,id),field($type,customField($type,fieldType($type,id),id,localizedName,name),id,name),id,removed,target,targetMember,timestamp),afterCursor,beforeCursor,hasAfter,hasBefore,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single ActivityCursorPage",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActivityCursorPage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/attachments" : {
+      "description" : "This resource lets you work with attachments in the specific issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url",
+            "default" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of IssueAttachment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/IssueAttachment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url",
+            "default" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "files[0]" : {
+                    "type" : "string",
+                    "format" : "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "collection of IssueAttachment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/IssueAttachment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/attachments/{issueAttachmentId}" : {
+      "description" : "This resource lets you work with attachments in the specific issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url",
+            "default" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueAttachmentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single IssueAttachment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueAttachment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url",
+            "default" : "$type,author($type,id,login,ringId),charset,created,extension,id,metaData,mimeType,name,size,updated,url"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueAttachmentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueAttachment"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueAttachment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueAttachment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueAttachmentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueAttachmentId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/comments" : {
+      "description" : "This resource lets you work with comments of an issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,attachments($type,id),author($type,id,login,ringId),created,deleted,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,attachments($type,id),author($type,id,login,ringId),created,deleted,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of IssueComment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/IssueComment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "draftId",
+          "in" : "query",
+          "description" : "ID of an existing draft that should be published. This parameter is optional.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,attachments($type,id),author($type,id,login,ringId),created,deleted,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,attachments($type,id),author($type,id,login,ringId),created,deleted,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueComment"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueComment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueComment"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/comments/{issueCommentId}" : {
+      "description" : "This resource lets you work with comments of an issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,attachments($type,id),author($type,id,login,ringId),created,deleted,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,attachments($type,id),author($type,id,login,ringId),created,deleted,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single IssueComment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueComment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,attachments($type,id),author($type,id,login,ringId),created,deleted,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,attachments($type,id),author($type,id,login,ringId),created,deleted,id,text,updated,visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueComment"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueComment",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueComment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueCommentId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/comments/{issueCommentId}/reactions" : {
+      "description" : "This resource lets you work with reactions to an issue comment.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Reaction",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Reaction"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Reaction"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Reaction",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Reaction"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/comments/{issueCommentId}/reactions/{reactionId}" : {
+      "description" : "This resource lets you work with reactions to an issue comment.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "reactionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Reaction",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Reaction"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCommentId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "reactionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueCommentId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "reactionId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/customFields" : {
+      "description" : "This resource lets you work with custom fields of the issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,value($type,id,name)",
+            "default" : "$type,id,name,value($type,id,name)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of IssueCustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/IssueCustomField"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/customFields/{issueCustomFieldId}" : {
+      "description" : "This resource lets you work with custom fields of the issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,value($type,id,name)",
+            "default" : "$type,id,name,value($type,id,name)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCustomFieldId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single IssueCustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueCustomField"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,value($type,id,name)",
+            "default" : "$type,id,name,value($type,id,name)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueCustomFieldId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueCustomField"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueCustomField",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueCustomField"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueCustomFieldId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/links" : {
+      "description" : "This resource lets you read links of the issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,direction,id,linkType($type,id,localizedName,name)",
+            "default" : "$type,direction,id,linkType($type,id,localizedName,name)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of IssueLink",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/IssueLink"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/links/{issueLinkId}" : {
+      "description" : "This resource lets you read links of the issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,direction,id,linkType($type,id,localizedName,name)",
+            "default" : "$type,direction,id,linkType($type,id,localizedName,name)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueLinkId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single IssueLink",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueLink"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueLinkId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/links/{issueLinkId}/issues" : {
+      "description" : "This resource lets you read, add, and remove links to other issues for the current one.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueLinkId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Issue"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueLinkId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Issue"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/links/{issueLinkId}/issues/{issueId}" : {
+      "description" : "This resource lets you read, add, and remove links to other issues for the current one.",
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueLinkId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueLinkId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/project" : {
+      "description" : "This resource lets you read the project where the issue belongs, and move the issue to another project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName",
+            "default" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Project",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName",
+            "default" : "$type,archived,customFields,id,leader($type,id,login,ringId),name,shortName"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Project"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Project",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/sprints" : {
+      "description" : "This resource lets you work with the sprints where the issue belongs.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,archived,finish,id,isDefault,name,start",
+            "default" : "$type,archived,finish,id,isDefault,name,start"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Sprint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Sprint"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/sprints/{sprintId}" : {
+      "description" : "This resource lets you work with the sprints where the issue belongs.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "sprintId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/tags" : {
+      "description" : "This sub-resource lets you work with the tags that are added to the specific issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Tag"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/tags/{tagId}" : {
+      "description" : "This sub-resource lets you work with the tags that are added to the specific issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "tagId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "tagId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "tagId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/timeTracking" : {
+      "description" : "This sub-resource lets you read work items of an issue and time tracking status in the issue's project.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,enabled,id",
+            "default" : "$type,enabled,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single IssueTimeTracker",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueTimeTracker"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/timeTracking/workItems" : {
+      "description" : "This resource lets you work with work items in the specific issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated",
+            "default" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of IssueWorkItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/IssueWorkItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated",
+            "default" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueWorkItem"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueWorkItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueWorkItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/timeTracking/workItems/{issueWorkItemId}" : {
+      "description" : "This resource lets you work with work items in the specific issue.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated",
+            "default" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueWorkItemId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single IssueWorkItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueWorkItem"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated",
+            "default" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueWorkItemId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueWorkItem"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueWorkItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueWorkItem"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "issueWorkItemId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueWorkItemId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issues/{id}/vcsChanges" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of VcsChange",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/VcsChange"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on issue changes caused by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VcsChange"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single VcsChange",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VcsChange"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issues/{id}/vcsChanges/{vcsChangeId}" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "vcsChangeId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single VcsChange",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VcsChange"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "muteUpdateNotifications",
+          "in" : "query",
+          "description" : "Set this parameter to `true` if no notifications should be sent on changes made by this request. This doesn't mute notifications sent by any workflow rules. Using this parameter requires <control>Apply Commands Silently</control> permission in all projects affected by the request. Available since 2021.3.",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "vcsChangeId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VcsChange"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single VcsChange",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VcsChange"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "vcsChangeId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "vcsChangeId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/issuesGetter/count" : {
+      "description" : "This resource lets you get the number of issues returned by a search.",
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,count,id",
+            "default" : "$type,count,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IssueCountResponse"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single IssueCountResponse",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueCountResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/permissions" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Permission",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Permission"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/permissions/{id}" : {
+      "description" : "",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/roles" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Role",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Role"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Role"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Role",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Role"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/roles/{id}" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Role",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Role"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Role"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Role",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Role"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/savedQueries" : {
+      "description" : "This resource lets you access and work with saved searches in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId),query",
+            "default" : "$type,id,name,owner($type,id,login,ringId),query"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of SavedQuery",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SavedQuery"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId),query",
+            "default" : "$type,id,name,owner($type,id,login,ringId),query"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SavedQuery"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single SavedQuery",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SavedQuery"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/savedQueries/{id}" : {
+      "description" : "This resource lets you access and work with saved searches in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId),query",
+            "default" : "$type,id,name,owner($type,id,login,ringId),query"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single SavedQuery",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SavedQuery"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId),query",
+            "default" : "$type,id,name,owner($type,id,login,ringId),query"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SavedQuery"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single SavedQuery",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SavedQuery"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/search/assist" : {
+      "description" : "Lets you get suggestions for the currently entered search query.",
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,suggestions($type,caret,completionEnd,completionStart,description,id,matchingEnd,matchingStart,option,prefix,suffix)",
+            "default" : "$type,id,suggestions($type,caret,completionEnd,completionStart,description,id,matchingEnd,matchingStart,option,prefix,suffix)"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SearchSuggestions"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single SearchSuggestions",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SearchSuggestions"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tags" : {
+      "description" : "This resource lets you access and work with tags in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "query",
+          "in" : "query",
+          "description" : "Tag search query. Use the name of the tag to filter the list of tags. To learn more about search queries, see <a href=\"api-query-syntax.topic\">Query Syntax</a>.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Tag"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tags/{id}" : {
+      "description" : "This resource lets you access and work with tags in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Tag"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/tags/{id}/issues" : {
+      "description" : "<p>This resource lets you get a list of issues that the specific tag is added to.</p><list><li>The default issue sorting is `sort by: updated desc`.</li><li>If you don't provide the `$top` parameter, the number of returned issues is limited to the <b>Max issues to export</b> value in the Global Settings of your YouTrack.</li></list>",
+      "get" : {
+        "parameters" : [ {
+          "name" : "customFields",
+          "in" : "query",
+          "description" : "<p>The name of the custom field to show in the response. When you use this parameter and request the custom field data in the request URL, the response only shows the requested custom fields instead of all of them.</p><p>To show more than one custom field, use this parameter several times.</p><p>See Sample 2 for reference.</p>",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))",
+            "default" : "$type,created,customFields($type,id,name,value($type,id,name)),description,id,idReadable,links($type,direction,id,linkType($type,id,localizedName,name)),numberInProject,project($type,id,name,shortName),reporter($type,id,login,ringId),resolved,summary,updated,updater($type,id,login,ringId),visibility($type,id,permittedGroups($type,id,name,ringId),permittedUsers($type,id,login,ringId))"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Issue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Issue"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tags/{id}/issues/{issueId}" : {
+      "description" : "<p>This resource lets you get a list of issues that the specific tag is added to.</p><list><li>The default issue sorting is `sort by: updated desc`.</li><li>If you don't provide the `$top` parameter, the number of returned issues is limited to the <b>Max issues to export</b> value in the Global Settings of your YouTrack.</li></list>",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "issueId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/users" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}" : {
+      "description" : "",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single User",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/users/{id}/profiles/general" : {
+      "description" : "This resource lets you read and update general settings in the YouTrack profile of the specified user.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,locale($type,community,id,language,locale,name),timezone($type,id,offset,presentation)",
+            "default" : "$type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,locale($type,community,id,language,locale,name),timezone($type,id,offset,presentation)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single GeneralUserProfile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GeneralUserProfile"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,locale($type,community,id,language,locale,name),timezone($type,id,offset,presentation)",
+            "default" : "$type,dateFieldFormat($type,datePattern,id,pattern,presentation),id,locale($type,community,id,language,locale,name),timezone($type,id,offset,presentation)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/GeneralUserProfile"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single GeneralUserProfile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GeneralUserProfile"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/profiles/notifications" : {
+      "description" : "This resource lets you read and update notification settings in the profile of the specific user.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single NotificationsUserProfile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NotificationsUserProfile"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id",
+            "default" : "$type,id"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NotificationsUserProfile"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single NotificationsUserProfile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NotificationsUserProfile"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/profiles/timetracking" : {
+      "description" : "This resource lets you configure the time tracking settings in the user's profile.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,periodFormat($type,id)",
+            "default" : "$type,id,periodFormat($type,id)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single TimeTrackingUserProfile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TimeTrackingUserProfile"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,periodFormat($type,id)",
+            "default" : "$type,id,periodFormat($type,id)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TimeTrackingUserProfile"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "single TimeTrackingUserProfile",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TimeTrackingUserProfile"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/savedQueries" : {
+      "description" : "This resource lets you get the list of saved searches that the specific user created.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId),query",
+            "default" : "$type,id,name,owner($type,id,login,ringId),query"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of SavedQuery",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SavedQuery"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/savedQueries/{savedQueryId}" : {
+      "description" : "This resource lets you get the list of saved searches that the specific user created.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "savedQueryId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/users/{id}/tags" : {
+      "description" : "This resource lets you work with tags that belong to specific user.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,id,name,owner($type,id,login,ringId)",
+            "default" : "$type,id,name,owner($type,id,login,ringId)"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of Tag",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}/tags/{tagId}" : {
+      "description" : "This resource lets you work with tags that belong to specific user.",
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      }, {
+        "name" : "tagId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/users/me" : {
+      "description" : "This resource lets you read the settings of your account and your own profile in YouTrack.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,banned,email,fullName,guest,id,login,ringId",
+            "default" : "$type,banned,email,fullName,guest,id,login,ringId"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single Me",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Me"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workItems" : {
+      "description" : "Resource that provides access to work items.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "query",
+          "in" : "query",
+          "description" : "Issue search query. Read more about the search syntax here: <a href=\"https://www.jetbrains.com/help/youtrack/cloud/?Search-and-Command-Attributes\">Search Query Reference</a>",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "startDate",
+          "in" : "query",
+          "description" : "The start date of the time interval where the work item dates belong. Accepts a date in a string format: `YYYY-MM-DD`.",
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "endDate",
+          "in" : "query",
+          "description" : "The end date of the time interval where the work item dates belong. Accepts a date in a string format: `YYYY-MM-DD`.",
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "start",
+          "in" : "query",
+          "description" : "A timestamp in milliseconds indicating the start of the interval where the work item dates belong.",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "end",
+          "in" : "query",
+          "description" : "A timestamp in milliseconds indicating the end of the interval where the work item dates belong.",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "createdStart",
+          "in" : "query",
+          "description" : "A timestamp in milliseconds indicating the start of the interval during which work items were created.",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "createdEnd",
+          "in" : "query",
+          "description" : "A timestamp in milliseconds indicating the end of the interval during which work items were created.",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "updatedStart",
+          "in" : "query",
+          "description" : "A timestamp in milliseconds indicating the start of the interval during which work items were updated.",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "updatedEnd",
+          "in" : "query",
+          "description" : "A timestamp in milliseconds indicating the end of the interval during which work items were updated.",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "author",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "creator",
+          "in" : "query",
+          "description" : "",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated",
+            "default" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated"
+          }
+        }, {
+          "name" : "$skip",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "$top",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "collection of IssueWorkItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/IssueWorkItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workItems/{id}" : {
+      "description" : "Resource that provides access to work items.",
+      "get" : {
+        "parameters" : [ {
+          "name" : "fields",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "example" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated",
+            "default" : "$type,author($type,id,login,ringId),created,creator($type,id,login,ringId),date,duration($type,id),id,text,updated"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "single IssueWorkItem",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IssueWorkItem"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "name" : "id",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "AccessScope" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "AccessScope" : "#/components/schemas/AccessScope",
+            "GlobalScope" : "#/components/schemas/GlobalScope",
+            "OrganizationScope" : "#/components/schemas/OrganizationScope",
+            "ProjectScope" : "#/components/schemas/ProjectScope"
+          }
+        }
+      },
+      "ActivityCategory" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "ActivityCursorPage" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "activities" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/ActivityItem"
+            }
+          },
+          "afterCursor" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "beforeCursor" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "hasAfter" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "hasBefore" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "reverse" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "ActivityItem" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "added" : {
+            "type" : "object",
+            "readOnly" : true
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "readOnly" : true
+          },
+          "category" : {
+            "$ref" : "#/components/schemas/ActivityCategory",
+            "readOnly" : true
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/FilterField",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "removed" : {
+            "type" : "object",
+            "readOnly" : true
+          },
+          "target" : {
+            "type" : "object",
+            "readOnly" : true
+          },
+          "targetMember" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "timestamp" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "ActivityItem" : "#/components/schemas/ActivityItem",
+            "VcsChangeActivityItem" : "#/components/schemas/VcsChangeActivityItem",
+            "PullRequestChangeActivityItem" : "#/components/schemas/PullRequestChangeActivityItem",
+            "WorkItemActivityItem" : "#/components/schemas/WorkItemActivityItem",
+            "WorkItemAuthorActivityItem" : "#/components/schemas/WorkItemAuthorActivityItem",
+            "WorkItemDurationActivityItem" : "#/components/schemas/WorkItemDurationActivityItem",
+            "WorkItemTypeActivityItem" : "#/components/schemas/WorkItemTypeActivityItem",
+            "SprintActivityItem" : "#/components/schemas/SprintActivityItem",
+            "CreatedDeletedActivityItem" : "#/components/schemas/CreatedDeletedActivityItem",
+            "AttachmentActivityItem" : "#/components/schemas/AttachmentActivityItem",
+            "CommentActivityItem" : "#/components/schemas/CommentActivityItem",
+            "IssueCreatedActivityItem" : "#/components/schemas/IssueCreatedActivityItem",
+            "IssueResolvedActivityItem" : "#/components/schemas/IssueResolvedActivityItem",
+            "SingleValueActivityItem" : "#/components/schemas/SingleValueActivityItem",
+            "SimpleValueActivityItem" : "#/components/schemas/SimpleValueActivityItem",
+            "TextMarkupActivityItem" : "#/components/schemas/TextMarkupActivityItem",
+            "UsesMarkupActivityItem" : "#/components/schemas/UsesMarkupActivityItem",
+            "ProjectActivityItem" : "#/components/schemas/ProjectActivityItem",
+            "MultiValueActivityItem" : "#/components/schemas/MultiValueActivityItem",
+            "CommentAttachmentsActivityItem" : "#/components/schemas/CommentAttachmentsActivityItem",
+            "LinksActivityItem" : "#/components/schemas/LinksActivityItem",
+            "TagsActivityItem" : "#/components/schemas/TagsActivityItem",
+            "VotersActivityItem" : "#/components/schemas/VotersActivityItem",
+            "VisibilityActivityItem" : "#/components/schemas/VisibilityActivityItem",
+            "VisibilityGroupActivityItem" : "#/components/schemas/VisibilityGroupActivityItem",
+            "VisibilityUserActivityItem" : "#/components/schemas/VisibilityUserActivityItem",
+            "CustomFieldActivityItem" : "#/components/schemas/CustomFieldActivityItem",
+            "TextCustomFieldActivityItem" : "#/components/schemas/TextCustomFieldActivityItem"
+          }
+        }
+      },
+      "Agile" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "owner" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "visibleFor" : {
+            "$ref" : "#/components/schemas/UserGroup",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "visibleForProjectBased" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "updateableBy" : {
+            "$ref" : "#/components/schemas/UserGroup",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "updateableByProjectBased" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "readSharingSettings" : {
+            "$ref" : "#/components/schemas/AgileSharingSettings",
+            "readOnly" : true
+          },
+          "updateSharingSettings" : {
+            "$ref" : "#/components/schemas/AgileSharingSettings",
+            "readOnly" : true
+          },
+          "orphansAtTheTop" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "hideOrphansSwimlane" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "estimationField" : {
+            "$ref" : "#/components/schemas/CustomField",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "originalEstimationField" : {
+            "$ref" : "#/components/schemas/CustomField",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "projects" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Project"
+            }
+          },
+          "sprints" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Sprint"
+            }
+          },
+          "currentSprint" : {
+            "$ref" : "#/components/schemas/Sprint",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "columnSettings" : {
+            "$ref" : "#/components/schemas/ColumnSettings",
+            "readOnly" : true
+          },
+          "swimlaneSettings" : {
+            "$ref" : "#/components/schemas/SwimlaneSettings",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "sprintsSettings" : {
+            "$ref" : "#/components/schemas/SprintsSettings",
+            "readOnly" : true
+          },
+          "colorCoding" : {
+            "$ref" : "#/components/schemas/ColorCoding",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "status" : {
+            "$ref" : "#/components/schemas/AgileStatus",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "AgileColumn" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "presentation" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "isResolved" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "parent" : {
+            "$ref" : "#/components/schemas/ColumnSettings",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "wipLimit" : {
+            "$ref" : "#/components/schemas/WIPLimit",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "fieldValues" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/AgileColumnFieldValue"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents settings for a single board column",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "AgileColumnFieldValue" : {
+        "description" : "Represents a field value or values, parameterizing agile column.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseAttributeValue"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "name" : {
+              "type" : "string",
+              "readOnly" : false
+            },
+            "isResolved" : {
+              "type" : "boolean",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "AgileSharingSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "permittedGroups" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/UserGroup"
+            }
+          },
+          "permittedUsers" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/User"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Stores users and groups that have access to an agile board.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "AgileStatus" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "valid" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "hasJobs" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "errors" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "warnings" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Shows if the board has any configuration problems.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "AllUsersGroup" : {
+        "description" : "Represents a group containing all users including guest.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/UserGroup"
+        } ]
+      },
+      "AppearanceSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "timeZone" : {
+            "$ref" : "#/components/schemas/TimeZoneDescriptor",
+            "readOnly" : false
+          },
+          "dateFieldFormat" : {
+            "$ref" : "#/components/schemas/DateFormatDescriptor",
+            "readOnly" : false
+          },
+          "logo" : {
+            "$ref" : "#/components/schemas/Logo",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "Article" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BaseArticle"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "attachments" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/ArticleAttachment"
+              }
+            },
+            "childArticles" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/Article"
+              }
+            },
+            "comments" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/ArticleComment"
+              }
+            },
+            "content" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "created" : {
+              "type" : "integer",
+              "format" : "int64",
+              "readOnly" : true
+            },
+            "externalArticle" : {
+              "$ref" : "#/components/schemas/ExternalArticle",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "hasChildren" : {
+              "type" : "boolean",
+              "readOnly" : true
+            },
+            "hasStar" : {
+              "type" : "boolean",
+              "readOnly" : false
+            },
+            "idReadable" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "ordinal" : {
+              "type" : "integer",
+              "format" : "int64",
+              "readOnly" : true
+            },
+            "parentArticle" : {
+              "$ref" : "#/components/schemas/Article",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "pinnedComments" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/ArticleComment"
+              }
+            },
+            "project" : {
+              "$ref" : "#/components/schemas/Project",
+              "readOnly" : true
+            },
+            "reporter" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "summary" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "tags" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/Tag"
+              }
+            },
+            "updated" : {
+              "type" : "integer",
+              "format" : "int64",
+              "readOnly" : true
+            },
+            "updatedBy" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "visibility" : {
+              "$ref" : "#/components/schemas/Visibility",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "ArticleAttachment" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "created" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "updated" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "size" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "extension" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "charset" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "mimeType" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "metaData" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "draft" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "removed" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "base64Content" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "url" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "visibility" : {
+            "$ref" : "#/components/schemas/Visibility",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "article" : {
+            "$ref" : "#/components/schemas/BaseArticle",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "comment" : {
+            "$ref" : "#/components/schemas/ArticleComment",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "ArticleComment" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "article" : {
+            "$ref" : "#/components/schemas/Article",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "attachments" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/ArticleAttachment"
+            }
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "created" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "pinned" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "reactions" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Reaction"
+            }
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "updated" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "visibility" : {
+            "$ref" : "#/components/schemas/Visibility",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "AssignedRole" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "role" : {
+            "$ref" : "#/components/schemas/Role",
+            "readOnly" : false
+          },
+          "scope" : {
+            "$ref" : "#/components/schemas/AccessScope",
+            "readOnly" : false
+          },
+          "holder" : {
+            "type" : "object",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "AttachmentActivityItem" : {
+        "description" : "Represents a change in the list of attachments of an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CreatedDeletedActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/IssueAttachment"
+              }
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/IssueAttachment"
+              }
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/IssueAttachment",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "AttributeBasedSwimlaneSettings" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SwimlaneSettings"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "field" : {
+              "$ref" : "#/components/schemas/FilterField",
+              "readOnly" : false
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/SwimlaneEntityAttributeValue"
+              }
+            }
+          }
+        } ]
+      },
+      "BackupError" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "date" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "errorMessage" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents an error that appeared during the backup.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "BackupFile" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "size" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "creationDate" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "link" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "BackupStatus" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "backupInProgress" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "backupCancelled" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "backupError" : {
+            "$ref" : "#/components/schemas/BackupError",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "BaseArticle" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "attachments" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/ArticleAttachment"
+            }
+          },
+          "content" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "reporter" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "summary" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "visibility" : {
+            "$ref" : "#/components/schemas/Visibility",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a base article entity.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "BaseArticle" : "#/components/schemas/BaseArticle",
+            "Article" : "#/components/schemas/Article"
+          }
+        }
+      },
+      "BaseBundle" : {
+        "description" : "Represents a set of field values in YouTrack.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Bundle"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/BundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "BaseWorkItem" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a basic ancestor for work items.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "BaseWorkItem" : "#/components/schemas/BaseWorkItem",
+            "IssueWorkItem" : "#/components/schemas/IssueWorkItem"
+          }
+        }
+      },
+      "BitBucketChangesProcessor" : {
+        "description" : "Represents an integration with a VCS repository hosted on bitbucket.org.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/BitBucketServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "BitBucketServer" : {
+        "description" : "Represents a cloud Bitbucket server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "BitbucketStandaloneChangesProcessor" : {
+        "description" : "Represents an integration with a VCS repository on a self-hosted Bitbucket server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/BitbucketStandaloneServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "BitbucketStandaloneServer" : {
+        "description" : "Represents a self-hosted Bitbucket server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "BuildBundle" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BaseBundle"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/BuildBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "BuildBundleCustomFieldDefaults" : {
+        "description" : "Default settings for the build-type field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleCustomFieldDefaults"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/BuildBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/BuildBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "BuildBundleElement" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleElement"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "assembleDate" : {
+              "type" : "integer",
+              "format" : "int64",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "BuildProjectCustomField" : {
+        "description" : "Represents project settings for a build field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/BuildBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/BuildBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "Bundle" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "isUpdateable" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "Bundle" : "#/components/schemas/Bundle",
+            "BaseBundle" : "#/components/schemas/BaseBundle",
+            "StateBundle" : "#/components/schemas/StateBundle",
+            "EnumBundle" : "#/components/schemas/EnumBundle",
+            "UserBundle" : "#/components/schemas/UserBundle",
+            "OwnedBundle" : "#/components/schemas/OwnedBundle",
+            "VersionBundle" : "#/components/schemas/VersionBundle",
+            "BuildBundle" : "#/components/schemas/BuildBundle"
+          }
+        }
+      },
+      "BundleCustomFieldDefaults" : {
+        "description" : "Represents custom field default settings for enumerated fields.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CustomFieldDefaults"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "BundleElement" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "bundle" : {
+            "$ref" : "#/components/schemas/Bundle",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "description" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "archived" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "color" : {
+            "$ref" : "#/components/schemas/FieldStyle",
+            "readOnly" : false
+          },
+          "hasRunningJob" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a field value in YouTrack.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "BundleElement" : "#/components/schemas/BundleElement",
+            "LocalizableBundleElement" : "#/components/schemas/LocalizableBundleElement",
+            "StateBundleElement" : "#/components/schemas/StateBundleElement",
+            "EnumBundleElement" : "#/components/schemas/EnumBundleElement",
+            "OwnedBundleElement" : "#/components/schemas/OwnedBundleElement",
+            "VersionBundleElement" : "#/components/schemas/VersionBundleElement",
+            "BuildBundleElement" : "#/components/schemas/BuildBundleElement"
+          }
+        }
+      },
+      "BundleProjectCustomField" : {
+        "description" : "Represents project settings for a custom field with a defined set of values.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ProjectCustomField"
+        } ]
+      },
+      "ChangesProcessor" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "server" : {
+            "$ref" : "#/components/schemas/VcsServer",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "project" : {
+            "$ref" : "#/components/schemas/Project",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "relatedProjects" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Project"
+            }
+          },
+          "enabled" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "visibleForGroups" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/UserGroup"
+            }
+          },
+          "addComments" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "lookupIssuesInBranchName" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "The basic entity that represents a VCS or a build server integration configured for a project.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "ChangesProcessor" : "#/components/schemas/ChangesProcessor",
+            "VcsHostingChangesProcessor" : "#/components/schemas/VcsHostingChangesProcessor",
+            "GitHubChangesProcessor" : "#/components/schemas/GitHubChangesProcessor",
+            "GogsChangesProcessor" : "#/components/schemas/GogsChangesProcessor",
+            "GiteaChangesProcessor" : "#/components/schemas/GiteaChangesProcessor",
+            "SpaceChangesProcessor" : "#/components/schemas/SpaceChangesProcessor",
+            "GitLabChangesProcessor" : "#/components/schemas/GitLabChangesProcessor",
+            "BitBucketChangesProcessor" : "#/components/schemas/BitBucketChangesProcessor",
+            "BitbucketStandaloneChangesProcessor" : "#/components/schemas/BitbucketStandaloneChangesProcessor",
+            "TeamcityChangesProcessor" : "#/components/schemas/TeamcityChangesProcessor",
+            "JenkinsChangesProcessor" : "#/components/schemas/JenkinsChangesProcessor"
+          }
+        }
+      },
+      "ColorCoding" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Describes rules that define which colors are used for cards on the agile board.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "ColorCoding" : "#/components/schemas/ColorCoding",
+            "FieldBasedColorCoding" : "#/components/schemas/FieldBasedColorCoding",
+            "ProjectBasedColorCoding" : "#/components/schemas/ProjectBasedColorCoding"
+          }
+        }
+      },
+      "ColumnSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/CustomField",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "columns" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/AgileColumn"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Agile board columns settings.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "CommandLimitedVisibility" : {
+        "description" : "Stores the restricted visibility settings for the command.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CommandVisibility"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "permittedGroups" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            },
+            "permittedUsers" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        } ]
+      },
+      "CommandList" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "comment" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "visibility" : {
+            "$ref" : "#/components/schemas/CommandVisibility",
+            "readOnly" : false
+          },
+          "query" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "caret" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "silent" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "runAs" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "commands" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/ParsedCommand"
+            }
+          },
+          "issues" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Issue"
+            }
+          },
+          "suggestions" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/Suggestion"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "CommandUnlimitedVisibility" : {
+        "description" : "Comment is visible for all the users who can read the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CommandVisibility"
+        } ]
+      },
+      "CommandVisibility" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Visibility settings of the comment that is added along with the command.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "CommandVisibility" : "#/components/schemas/CommandVisibility",
+            "CommandUnlimitedVisibility" : "#/components/schemas/CommandUnlimitedVisibility",
+            "CommandLimitedVisibility" : "#/components/schemas/CommandLimitedVisibility"
+          }
+        }
+      },
+      "CommentActivityItem" : {
+        "description" : "Represents a change in the comments of an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CreatedDeletedActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/IssueComment"
+              }
+            },
+            "authorGroup" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/IssueComment"
+              }
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/IssueComment",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "CommentAttachmentsActivityItem" : {
+        "description" : "Represents a change in the `attachments` attribute of an IssueComment.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/MultiValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/IssueAttachment"
+              }
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/IssueAttachment"
+              }
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/IssueComment",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "CreatedDeletedActivityItem" : {
+        "description" : "Represents an action when an entity is created or deleted in an issue. For example, a new comment is created in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "CustomField" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "localizedName" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "fieldType" : {
+            "$ref" : "#/components/schemas/FieldType",
+            "readOnly" : false
+          },
+          "isAutoAttached" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "isDisplayedInIssueList" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "aliases" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "fieldDefaults" : {
+            "$ref" : "#/components/schemas/CustomFieldDefaults",
+            "readOnly" : true
+          },
+          "hasRunningJob" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "isUpdateable" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "instances" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/ProjectCustomField"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "CustomFieldActivityItem" : {
+        "description" : "Represents an activity that affects a custom field of an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/Issue",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "CustomFieldCondition" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "parent" : {
+            "$ref" : "#/components/schemas/ProjectCustomField",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the condition for showing a custom field.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "CustomFieldCondition" : "#/components/schemas/CustomFieldCondition",
+            "FieldBasedCondition" : "#/components/schemas/FieldBasedCondition"
+          }
+        }
+      },
+      "CustomFieldDefaults" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "canBeEmpty" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "emptyFieldText" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "isPublic" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "parent" : {
+            "$ref" : "#/components/schemas/CustomField",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "CustomFieldDefaults" : "#/components/schemas/CustomFieldDefaults",
+            "BundleCustomFieldDefaults" : "#/components/schemas/BundleCustomFieldDefaults",
+            "UserCustomFieldDefaults" : "#/components/schemas/UserCustomFieldDefaults",
+            "BuildBundleCustomFieldDefaults" : "#/components/schemas/BuildBundleCustomFieldDefaults",
+            "StateBundleCustomFieldDefaults" : "#/components/schemas/StateBundleCustomFieldDefaults",
+            "VersionBundleCustomFieldDefaults" : "#/components/schemas/VersionBundleCustomFieldDefaults",
+            "EnumBundleCustomFieldDefaults" : "#/components/schemas/EnumBundleCustomFieldDefaults",
+            "OwnedBundleCustomFieldDefaults" : "#/components/schemas/OwnedBundleCustomFieldDefaults"
+          }
+        }
+      },
+      "CustomFilterField" : {
+        "description" : "Represents a custom field of the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/FilterField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "customField" : {
+              "$ref" : "#/components/schemas/CustomField",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "DatabaseAttributeValue" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents string reference to the value.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "DatabaseAttributeValue" : "#/components/schemas/DatabaseAttributeValue",
+            "SwimlaneEntityAttributeValue" : "#/components/schemas/SwimlaneEntityAttributeValue",
+            "AgileColumnFieldValue" : "#/components/schemas/AgileColumnFieldValue"
+          }
+        }
+      },
+      "DatabaseBackupSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "location" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "filesToKeep" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "cronExpression" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "archiveFormat" : {
+            "type" : "string",
+            "readOnly" : false,
+            "enum" : [ "TAR_GZ", "ZIP" ]
+          },
+          "isOn" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "availableDiskSpace" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "notifiedUsers" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/User"
+            }
+          },
+          "backupStatus" : {
+            "$ref" : "#/components/schemas/BackupStatus",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "DateFormatDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "presentation" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "pattern" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "datePattern" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents date format.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "DateIssueCustomField" : {
+        "description" : "Represents a date-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SimpleIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "object",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "DuplicateVote" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "issue" : {
+            "$ref" : "#/components/schemas/Issue",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "user" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a vote for duplicates of the issue.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "DurationValue" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "minutes" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "presentation" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the duration value and its visual presentation.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "EmailSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "isEnabled" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "host" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "port" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "mailProtocol" : {
+            "type" : "string",
+            "readOnly" : false,
+            "enum" : [ "SMTP", "SMTPS", "SMTP_TLS", "MS_GRAPH_API" ]
+          },
+          "anonymous" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "login" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "sslKey" : {
+            "$ref" : "#/components/schemas/StorageEntry",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "from" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "replyTo" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents email settings for this YouTrack installation.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "EnumBundle" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BaseBundle"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/EnumBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "EnumBundleCustomFieldDefaults" : {
+        "description" : "Default settings for the enum-type field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleCustomFieldDefaults"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/EnumBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/EnumBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "EnumBundleElement" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/LocalizableBundleElement"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "EnumProjectCustomField" : {
+        "description" : "Represents project settings for the enum field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/EnumBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/EnumBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "Event" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "presentation" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a transition from one value to another for a custom field that is managed by a state-machine rule in workflow.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "ExternalArticle" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "url" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "key" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "For an article that was imported from another service, this entity represents the reference to the article in the external system.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "ExternalIssue" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "url" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "key" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "For an issue that was imported from another service, represents the reference to the issue in the external system.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "FieldBasedColorCoding" : {
+        "description" : "Sets a card color based on a value of some custom field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ColorCoding"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "prototype" : {
+              "$ref" : "#/components/schemas/CustomField",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "FieldBasedCondition" : {
+        "description" : "Represents the condition for showing a custom field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CustomFieldCondition"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "field" : {
+              "$ref" : "#/components/schemas/BundleProjectCustomField",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/BundleElement"
+              }
+            },
+            "showForNullValue" : {
+              "type" : "boolean",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "FieldStyle" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "background" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "foreground" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the style settings of the field in YouTrack.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "FieldType" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "FilterField" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "presentation" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents an issue property, which can be a predefined field, a custom field, a link, and so on.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "FilterField" : "#/components/schemas/FilterField",
+            "PredefinedFilterField" : "#/components/schemas/PredefinedFilterField",
+            "CustomFilterField" : "#/components/schemas/CustomFilterField"
+          }
+        }
+      },
+      "GeneralUserProfile" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "dateFieldFormat" : {
+            "$ref" : "#/components/schemas/DateFormatDescriptor",
+            "readOnly" : false
+          },
+          "timezone" : {
+            "$ref" : "#/components/schemas/TimeZoneDescriptor",
+            "readOnly" : false
+          },
+          "locale" : {
+            "$ref" : "#/components/schemas/LocaleDescriptor",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "GitHubChangesProcessor" : {
+        "description" : "Represents a GitHub integration configured for a project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/GitHubServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "GitHubServer" : {
+        "description" : "Represents a GitHub server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "GitLabChangesProcessor" : {
+        "description" : "Represents a GitLab integration configured for a project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/GitLabServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "GitLabServer" : {
+        "description" : "Represents a GitLab server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "GiteaChangesProcessor" : {
+        "description" : "Represents a Gitea integration configured for a project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/GiteaServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "GiteaServer" : {
+        "description" : "Represents a Gitea server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "GlobalScope" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AccessScope"
+        } ]
+      },
+      "GlobalSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "systemSettings" : {
+            "$ref" : "#/components/schemas/SystemSettings",
+            "readOnly" : true
+          },
+          "notificationSettings" : {
+            "$ref" : "#/components/schemas/NotificationSettings",
+            "readOnly" : true
+          },
+          "restSettings" : {
+            "$ref" : "#/components/schemas/RestCorsSettings",
+            "readOnly" : true
+          },
+          "appearanceSettings" : {
+            "$ref" : "#/components/schemas/AppearanceSettings",
+            "readOnly" : true
+          },
+          "localeSettings" : {
+            "$ref" : "#/components/schemas/LocaleSettings",
+            "readOnly" : true
+          },
+          "license" : {
+            "$ref" : "#/components/schemas/License",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "GlobalTimeTrackingSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "workItemTypes" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/WorkItemType"
+            }
+          },
+          "workTimeSettings" : {
+            "$ref" : "#/components/schemas/WorkTimeSettings",
+            "readOnly" : true
+          },
+          "attributePrototypes" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/WorkItemAttributePrototype"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "GogsChangesProcessor" : {
+        "description" : "Represents a Gogs integration configured for a project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/GogsServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "GogsServer" : {
+        "description" : "Represents a Gogs server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "GroupProjectCustomField" : {
+        "description" : "Represents project settings for a group custom field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            }
+          }
+        } ]
+      },
+      "Issue" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "attachments" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueAttachment"
+            }
+          },
+          "comments" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueComment"
+            }
+          },
+          "commentsCount" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "created" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "customFields" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueCustomField"
+            }
+          },
+          "description" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "draftOwner" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "externalIssue" : {
+            "$ref" : "#/components/schemas/ExternalIssue",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "idReadable" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "isDraft" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "links" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueLink"
+            }
+          },
+          "numberInProject" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "parent" : {
+            "$ref" : "#/components/schemas/IssueLink",
+            "readOnly" : true
+          },
+          "pinnedComments" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueComment"
+            }
+          },
+          "project" : {
+            "$ref" : "#/components/schemas/Project",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "reporter" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "resolved" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "subtasks" : {
+            "$ref" : "#/components/schemas/IssueLink",
+            "readOnly" : true
+          },
+          "summary" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "tags" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Tag"
+            }
+          },
+          "updated" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "updater" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "visibility" : {
+            "$ref" : "#/components/schemas/Visibility",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "voters" : {
+            "$ref" : "#/components/schemas/IssueVoters",
+            "readOnly" : true
+          },
+          "votes" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "watchers" : {
+            "$ref" : "#/components/schemas/IssueWatchers",
+            "readOnly" : true
+          },
+          "wikifiedDescription" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueAttachment" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "created" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "updated" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "size" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "extension" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "charset" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "mimeType" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "metaData" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "draft" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "removed" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "base64Content" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "url" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "visibility" : {
+            "$ref" : "#/components/schemas/Visibility",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "issue" : {
+            "$ref" : "#/components/schemas/Issue",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "comment" : {
+            "$ref" : "#/components/schemas/IssueComment",
+            "readOnly" : true
+          },
+          "thumbnailURL" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueBasedSwimlaneSettings" : {
+        "description" : "Swimlane settings for the case, when each swimlane is represented by an issue and contains this issue's subtasks.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SwimlaneSettings"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "field" : {
+              "$ref" : "#/components/schemas/FilterField",
+              "readOnly" : false
+            },
+            "defaultCardType" : {
+              "$ref" : "#/components/schemas/SwimlaneValue",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/SwimlaneValue"
+              }
+            }
+          }
+        } ]
+      },
+      "IssueComment" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "attachments" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueAttachment"
+            }
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "created" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "deleted" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "issue" : {
+            "$ref" : "#/components/schemas/Issue",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "pinned" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "reactions" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Reaction"
+            }
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "textPreview" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "updated" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "visibility" : {
+            "$ref" : "#/components/schemas/Visibility",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueCountResponse" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "count" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "unresolvedOnly" : {
+            "type" : "boolean",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "query" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "folder" : {
+            "$ref" : "#/components/schemas/IssueFolder",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueCreatedActivityItem" : {
+        "description" : "Represents an event when a user creates a new issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CreatedDeletedActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/Issue",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "IssueCustomField" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "projectCustomField" : {
+            "$ref" : "#/components/schemas/ProjectCustomField",
+            "readOnly" : true
+          },
+          "value" : {
+            "type" : "object",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "IssueCustomField" : "#/components/schemas/IssueCustomField",
+            "PeriodIssueCustomField" : "#/components/schemas/PeriodIssueCustomField",
+            "SimpleIssueCustomField" : "#/components/schemas/SimpleIssueCustomField",
+            "DateIssueCustomField" : "#/components/schemas/DateIssueCustomField",
+            "SingleValueIssueCustomField" : "#/components/schemas/DatabaseSingleValueIssueCustomField",
+            "StateIssueCustomField" : "#/components/schemas/StateIssueCustomField",
+            "SingleBuildIssueCustomField" : "#/components/schemas/SingleBuildIssueCustomField",
+            "SingleUserIssueCustomField" : "#/components/schemas/SingleUserIssueCustomField",
+            "SingleGroupIssueCustomField" : "#/components/schemas/SingleGroupIssueCustomField",
+            "SingleVersionIssueCustomField" : "#/components/schemas/SingleVersionIssueCustomField",
+            "SingleOwnedIssueCustomField" : "#/components/schemas/SingleOwnedIssueCustomField",
+            "SingleEnumIssueCustomField" : "#/components/schemas/SingleEnumIssueCustomField",
+            "MultiValueIssueCustomField" : "#/components/schemas/DatabaseMultiValueIssueCustomField",
+            "MultiBuildIssueCustomField" : "#/components/schemas/MultiBuildIssueCustomField",
+            "MultiGroupIssueCustomField" : "#/components/schemas/MultiGroupIssueCustomField",
+            "MultiVersionIssueCustomField" : "#/components/schemas/MultiVersionIssueCustomField",
+            "MultiOwnedIssueCustomField" : "#/components/schemas/MultiOwnedIssueCustomField",
+            "MultiEnumIssueCustomField" : "#/components/schemas/MultiEnumIssueCustomField",
+            "MultiUserIssueCustomField" : "#/components/schemas/MultiUserIssueCustomField",
+            "StateMachineIssueCustomField" : "#/components/schemas/StateMachineIssueCustomField",
+            "TextIssueCustomField" : "#/components/schemas/TextIssueCustomField"
+          }
+        }
+      },
+      "IssueFolder" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents an issue folder, such as a project, a saved search, or a tag.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "IssueFolder" : "#/components/schemas/IssueFolder",
+            "WatchFolder" : "#/components/schemas/WatchFolder",
+            "IssueTag" : "#/components/schemas/IssueTag",
+            "StarWatchFolder" : "#/components/schemas/StarWatchFolder",
+            "Tag" : "#/components/schemas/Tag",
+            "SavedQuery" : "#/components/schemas/SavedQuery",
+            "Project" : "#/components/schemas/Project"
+          }
+        }
+      },
+      "IssueKey" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "project" : {
+            "$ref" : "#/components/schemas/Project",
+            "readOnly" : true
+          },
+          "numberInProject" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Stores information about a project where the issue belongs or previously belonged. This entity appears as part of the ProjectActivityItem object.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueLink" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "direction" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "OUTWARD", "INWARD", "BOTH" ]
+          },
+          "linkType" : {
+            "$ref" : "#/components/schemas/IssueLinkType",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "issues" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Issue"
+            }
+          },
+          "trimmedIssues" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/Issue"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueLinkType" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "localizedName" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "sourceToTarget" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "localizedSourceToTarget" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "targetToSource" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "localizedTargetToSource" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "directed" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "aggregation" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "readOnly" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueResolvedActivityItem" : {
+        "description" : "Represents an event when a user resolves an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SimpleValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "integer",
+              "format" : "int64",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "integer",
+              "format" : "int64",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "IssueTag" : {
+        "description" : "<p>Deprecated. Use `Tag` instead.</p>",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Tag"
+        } ]
+      },
+      "IssueTimeTracker" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "workItems" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueWorkItem"
+            }
+          },
+          "enabled" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueVoters" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "hasVote" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "original" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/User"
+            }
+          },
+          "duplicate" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/DuplicateVote"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents users that have voted for the issue or its duplicates.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueWatcher" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "user" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "issue" : {
+            "$ref" : "#/components/schemas/Issue",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "isStarred" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a user who subscribed for notifications about an issue.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueWatchers" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "hasStar" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "issueWatchers" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueWatcher"
+            }
+          },
+          "duplicateWatchers" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueWatcher"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents users that are subscribed to notifications about the issue.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "IssueWorkItem" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BaseWorkItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "author" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "creator" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "text" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "textPreview" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "type" : {
+              "$ref" : "#/components/schemas/WorkItemType",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "created" : {
+              "type" : "integer",
+              "format" : "int64",
+              "readOnly" : false
+            },
+            "updated" : {
+              "type" : "integer",
+              "format" : "int64",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "duration" : {
+              "$ref" : "#/components/schemas/DurationValue",
+              "readOnly" : false
+            },
+            "date" : {
+              "type" : "integer",
+              "format" : "int64",
+              "readOnly" : false
+            },
+            "issue" : {
+              "$ref" : "#/components/schemas/Issue",
+              "readOnly" : true
+            },
+            "attributes" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/WorkItemAttribute"
+              }
+            }
+          }
+        } ]
+      },
+      "JenkinsChangesProcessor" : {
+        "description" : "Represents a Jenkins integration configured for a project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/JenkinsServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "JenkinsServer" : {
+        "description" : "Represents a Jenkins server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "License" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "username" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "license" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "error" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "LimitedVisibility" : {
+        "description" : "Represents visibility limited to several users and/or groups.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Visibility"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "permittedGroups" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            },
+            "permittedUsers" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        } ]
+      },
+      "LinksActivityItem" : {
+        "description" : "Represents a change in the `issues` attribute of an IssueLink entity.\nThat is, each issue has the `links` attribute that contains an array of IssueLink entities.\nEach of them represents a link between the target issue and a collection of issues.\nFor example, a set of issues to which the target one is linked as \"Duplicated by\".\nThe change in the list of these issues is represented by `LinksActivityItem` entity.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/MultiValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/Issue",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "LocaleDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "locale" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "language" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "community" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a language locale that is used in UI.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "LocaleSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "locale" : {
+            "$ref" : "#/components/schemas/LocaleDescriptor",
+            "readOnly" : false
+          },
+          "isRTL" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "LocalizableBundleElement" : {
+        "description" : "Represents field value that can be localized.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleElement"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "localizedName" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "Logo" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "url" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Company logo that is used in YouTrack.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "Me" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/User"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "MultiBuildIssueCustomField" : {
+        "description" : "Represents a multi-value build-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseMultiValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/BuildBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "MultiEnumIssueCustomField" : {
+        "description" : "Represents a multi-value enum-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseMultiValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/EnumBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "MultiGroupIssueCustomField" : {
+        "description" : "Represents a multi-value group-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseMultiValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            }
+          }
+        } ]
+      },
+      "MultiOwnedIssueCustomField" : {
+        "description" : "Represents a multi-value owned-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseMultiValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/OwnedBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "MultiUserIssueCustomField" : {
+        "description" : "Represents a multi-value user-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseMultiValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        } ]
+      },
+      "MultiValueActivityItem" : {
+        "description" : "Represents a change in an entity attribute that has type of `Array of &lt;Entities&gt;`.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "object",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "DatabaseMultiValueIssueCustomField" : {
+        "description" : "Represents a custom field that may have multiple values in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "object",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "MultiVersionIssueCustomField" : {
+        "description" : "Represents a multi-value version-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseMultiValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/VersionBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "NestedGroup" : {
+        "description" : "Represents a user group in YouTrack that either has a parent or subgroups.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/UserGroup"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "parentGroup" : {
+              "$ref" : "#/components/schemas/NestedGroup",
+              "readOnly" : false
+            },
+            "subGroups" : {
+              "$ref" : "#/components/schemas/NestedGroup",
+              "readOnly" : false
+            },
+            "ownUsers" : {
+              "$ref" : "#/components/schemas/User",
+              "readOnly" : false
+            },
+            "requireTwoFactorAuthentication" : {
+              "type" : "boolean",
+              "readOnly" : false
+            },
+            "viewers" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "updaters" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "autoJoin" : {
+              "type" : "boolean",
+              "readOnly" : false
+            },
+            "autoJoinDomain" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "NotificationSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "emailSettings" : {
+            "$ref" : "#/components/schemas/EmailSettings",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "NotificationsUserProfile" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "notifyOnOwnChanges" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "emailNotificationsEnabled" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "mentionNotificationsEnabled" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "duplicateClusterNotificationsEnabled" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "mailboxIntegrationNotificationsEnabled" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "usePlainTextEmails" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "autoWatchOnComment" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "autoWatchOnCreate" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "autoWatchOnVote" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "autoWatchOnUpdate" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "OnlineUsers" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "users" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Stores number of online user.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "Organization" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "key" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "description" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "iconUrl" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "projects" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Project"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "OrganizationScope" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AccessScope"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "organization" : {
+              "$ref" : "#/components/schemas/Organization",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "OwnedBundle" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BaseBundle"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/OwnedBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "OwnedBundleCustomFieldDefaults" : {
+        "description" : "Default settings for the owned-type field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleCustomFieldDefaults"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/OwnedBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/OwnedBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "OwnedBundleElement" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleElement"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "owner" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "OwnedProjectCustomField" : {
+        "description" : "Represents project settings for an owned field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/OwnedBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/OwnedBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "ParsedCommand" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "description" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "error" : {
+            "type" : "boolean",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "delete" : {
+            "type" : "boolean",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the command that was parsed from the provided query.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "PeriodFieldFormat" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the format, in which the period values are displayed to the user.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "PeriodIssueCustomField" : {
+        "description" : "Represents the period field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/PeriodValue",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "PeriodProjectCustomField" : {
+        "description" : "Represents project settings for the period field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "PeriodValue" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "minutes" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "presentation" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the period field value.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "Permission" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "description" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "permissionEntityType" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "operation" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "impliedPermissions" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/Permission"
+            }
+          },
+          "dependentPermissions" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/Permission"
+            }
+          },
+          "scope" : {
+            "type" : "object",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "PredefinedFilterField" : {
+        "description" : "Represents a predefined field of the issue. Predefined fields are always present in an issue and\n            |cannot be customized in a project. For example, `project`, `created`,\n            |`updated`, `tags`, and so on.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/FilterField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "Project" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IssueFolder"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "archived" : {
+              "type" : "boolean",
+              "readOnly" : false
+            },
+            "createdBy" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "customFields" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "description" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "fromEmail" : {
+              "type" : "string",
+              "readOnly" : false
+            },
+            "iconUrl" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "issues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            },
+            "leader" : {
+              "$ref" : "#/components/schemas/User",
+              "readOnly" : false
+            },
+            "name" : {
+              "type" : "string",
+              "readOnly" : false
+            },
+            "replyToEmail" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "shortName" : {
+              "type" : "string",
+              "readOnly" : false
+            },
+            "startingNumber" : {
+              "type" : "integer",
+              "format" : "int64",
+              "readOnly" : false
+            },
+            "team" : {
+              "$ref" : "#/components/schemas/ProjectTeam",
+              "readOnly" : true
+            },
+            "template" : {
+              "type" : "boolean",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "ProjectActivityItem" : {
+        "description" : "Represents the change in the project attribute on an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SingleValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "$ref" : "#/components/schemas/IssueKey",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "removed" : {
+              "$ref" : "#/components/schemas/IssueKey",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/Issue",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "ProjectBasedColorCoding" : {
+        "description" : "Lets you set a color for a card based on its project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ColorCoding"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "projectColors" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/ProjectColor"
+              }
+            }
+          }
+        } ]
+      },
+      "ProjectColor" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "project" : {
+            "$ref" : "#/components/schemas/Project",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "color" : {
+            "$ref" : "#/components/schemas/FieldStyle",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents color setting for one project on the board.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "ProjectCustomField" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/CustomField",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "project" : {
+            "$ref" : "#/components/schemas/Project",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "canBeEmpty" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "emptyFieldText" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "isPublic" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "hasRunningJob" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "condition" : {
+            "$ref" : "#/components/schemas/CustomFieldCondition",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "ProjectCustomField" : "#/components/schemas/ProjectCustomField",
+            "GroupProjectCustomField" : "#/components/schemas/GroupProjectCustomField",
+            "BundleProjectCustomField" : "#/components/schemas/BundleProjectCustomField",
+            "UserProjectCustomField" : "#/components/schemas/UserProjectCustomField",
+            "BuildProjectCustomField" : "#/components/schemas/BuildProjectCustomField",
+            "StateProjectCustomField" : "#/components/schemas/StateProjectCustomField",
+            "VersionProjectCustomField" : "#/components/schemas/VersionProjectCustomField",
+            "OwnedProjectCustomField" : "#/components/schemas/OwnedProjectCustomField",
+            "EnumProjectCustomField" : "#/components/schemas/EnumProjectCustomField",
+            "SimpleProjectCustomField" : "#/components/schemas/SimpleProjectCustomField",
+            "PeriodProjectCustomField" : "#/components/schemas/PeriodProjectCustomField",
+            "TextProjectCustomField" : "#/components/schemas/TextProjectCustomField"
+          }
+        }
+      },
+      "ProjectScope" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AccessScope"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "project" : {
+              "$ref" : "#/components/schemas/Project",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "ProjectTeam" : {
+        "description" : "User group representing all members of the project team.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/UserGroup"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "project" : {
+              "$ref" : "#/components/schemas/Project",
+              "readOnly" : true
+            },
+            "users" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            },
+            "ownUsers" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            },
+            "groups" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            }
+          }
+        } ]
+      },
+      "ProjectTimeTrackingSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "enabled" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "estimate" : {
+            "$ref" : "#/components/schemas/ProjectCustomField",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "timeSpent" : {
+            "$ref" : "#/components/schemas/ProjectCustomField",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "workItemTypes" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/WorkItemType"
+            }
+          },
+          "project" : {
+            "$ref" : "#/components/schemas/Project",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "attributes" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/WorkItemProjectAttribute"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "PullRequest" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "readOnly" : true
+          },
+          "userNotFoundReason" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "hubUserNotFoundReason" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "idExternal" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "idReadable" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "date" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "fetched" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "title" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "titlePreview" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "url" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "textPreview" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "branch" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "files" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "issue" : {
+            "$ref" : "#/components/schemas/Issue",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "processor" : {
+            "$ref" : "#/components/schemas/ChangesProcessor",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "PullRequestChange" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "readOnly" : true
+          },
+          "userNotFoundReason" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "hubUserNotFoundReason" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "fetched" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "state" : {
+            "$ref" : "#/components/schemas/PullRequestState",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "reopened" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "pullRequest" : {
+            "$ref" : "#/components/schemas/PullRequest",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a state change in a pull request linked to an issue.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "PullRequestChangeActivityItem" : {
+        "description" : "Represents an update in the list of pull request changes of an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CreatedDeletedActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/PullRequestChange"
+              }
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/PullRequestChange"
+              }
+            },
+            "author" : {
+              "$ref" : "#/components/schemas/User",
+              "readOnly" : true
+            },
+            "pullRequest" : {
+              "$ref" : "#/components/schemas/PullRequest",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "PullRequestState" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the state of a pull request.\nThe available states are `OPEN`, `MERGED`, and `DECLINED`.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "Reaction" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "reaction" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "RegisteredUsersGroup" : {
+        "description" : "Represents a group containing all users excluding guest.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/UserGroup"
+        } ]
+      },
+      "RestCorsSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "allowedOrigins" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "allowAllOrigins" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "Role" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "description" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "permissions" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/Permission"
+            }
+          },
+          "immutable" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "SavedQuery" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/WatchFolder"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "query" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "issues" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            },
+            "visibleFor" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "updateableBy" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "readSharingSettings" : {
+              "$ref" : "#/components/schemas/WatchFolderSharingSettings",
+              "readOnly" : true
+            },
+            "updateSharingSettings" : {
+              "$ref" : "#/components/schemas/WatchFolderSharingSettings",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "SearchSuggestions" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "caret" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "ignoreUnresolvedSetting" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "query" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "suggestions" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/Suggestion"
+            }
+          },
+          "folders" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/IssueFolder"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "SimpleIssueCustomField" : {
+        "description" : "Represents a simple-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "object",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "SimpleProjectCustomField" : {
+        "description" : "Represents project settings for the fields of the following types: `integer`, `float`, `date`, `date and time`, `string`.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "SimpleValueActivityItem" : {
+        "description" : "Represents the change in attributes of a simple type in the target entity:\nIssue, IssueComment, WorkItem, IssueAttachment.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SingleValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "object",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "SingleBuildIssueCustomField" : {
+        "description" : "Represents a single-value build-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseSingleValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/BuildBundleElement",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "SingleEnumIssueCustomField" : {
+        "description" : "Represents a single-value enum-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseSingleValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/EnumBundleElement",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "SingleGroupIssueCustomField" : {
+        "description" : "Represents a single-value group-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseSingleValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "SingleOwnedIssueCustomField" : {
+        "description" : "Represents a single-value owned-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseSingleValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/OwnedBundleElement",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "SingleUserIssueCustomField" : {
+        "description" : "Represents a single-value user-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseSingleValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/User",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "SingleValueActivityItem" : {
+        "description" : "Describe change of properties that can have single value.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "object",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "DatabaseSingleValueIssueCustomField" : {
+        "description" : "Represents a a single-value custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "object",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "SingleVersionIssueCustomField" : {
+        "description" : "Represents a single-value version-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseSingleValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/VersionBundleElement",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "SpaceChangesProcessor" : {
+        "description" : "Represents a Space integration configured for a project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/SpaceServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "SpaceServer" : {
+        "description" : "Represents a Space server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsHostingServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "Sprint" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "agile" : {
+            "$ref" : "#/components/schemas/Agile",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "goal" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "start" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "finish" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "archived" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "isDefault" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "issues" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/Issue"
+            }
+          },
+          "unresolvedIssuesCount" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "previousSprint" : {
+            "$ref" : "#/components/schemas/Sprint",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "SprintActivityItem" : {
+        "description" : "Represents a change in the issue when it was added to or removed from an agile board sprint.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/MultiValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/Issue",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Sprint"
+              }
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Sprint"
+              }
+            }
+          }
+        } ]
+      },
+      "SprintsSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "isExplicit" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "cardOnSeveralSprints" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "defaultSprint" : {
+            "$ref" : "#/components/schemas/Sprint",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "disableSprints" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "explicitQuery" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "sprintSyncField" : {
+            "$ref" : "#/components/schemas/CustomField",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "hideSubtasksOfCards" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Describes sprints configuration.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "StarWatchFolder" : {
+        "description" : "Represents the Star folder.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/WatchFolder"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "removeOnResolve" : {
+              "type" : "boolean",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "StateBundle" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BaseBundle"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/StateBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "StateBundleCustomFieldDefaults" : {
+        "description" : "Default settings for the state-type field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleCustomFieldDefaults"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/StateBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/StateBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "StateBundleElement" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/LocalizableBundleElement"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "isResolved" : {
+              "type" : "boolean",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "StateIssueCustomField" : {
+        "description" : "Represents a single-value state-type custom field in the issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseSingleValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/StateBundleElement",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "StateMachineIssueCustomField" : {
+        "description" : "Represents the issue custom field that is managed by a state-machine rule in workflow.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseSingleValueIssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "type" : "object",
+              "readOnly" : true
+            },
+            "event" : {
+              "$ref" : "#/components/schemas/Event",
+              "readOnly" : true
+            },
+            "possibleEvents" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Event"
+              }
+            }
+          }
+        } ]
+      },
+      "StateProjectCustomField" : {
+        "description" : "Represents project settings for a state field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/StateBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/StateBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "StorageEntry" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "SSL key representation.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "Suggestion" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "completionStart" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "completionEnd" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "matchingStart" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "matchingEnd" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "caret" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "description" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "option" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "prefix" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "suffix" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "group" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "icon" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "auxiliaryIcon" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "className" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents query suggestion.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "SwimlaneEntityAttributeValue" : {
+        "description" : "Represents a single swimlane in case of AttributeBasedSwimlaneSettings.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/DatabaseAttributeValue"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "name" : {
+              "type" : "string",
+              "readOnly" : false
+            },
+            "isResolved" : {
+              "type" : "boolean",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "SwimlaneSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "enabled" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Base entity for different swimlane settings",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "SwimlaneSettings" : "#/components/schemas/SwimlaneSettings",
+            "AttributeBasedSwimlaneSettings" : "#/components/schemas/AttributeBasedSwimlaneSettings",
+            "IssueBasedSwimlaneSettings" : "#/components/schemas/IssueBasedSwimlaneSettings"
+          }
+        }
+      },
+      "SwimlaneValue" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents single swimlane in case of IssueBasedSwimlaneSettings.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "SystemSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "baseUrl" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "maxUploadFileSize" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : false
+          },
+          "maxExportItems" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "administratorEmail" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "allowStatisticsCollection" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "isApplicationReadOnly" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "Tag" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/WatchFolder"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "issues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/Issue"
+              }
+            },
+            "color" : {
+              "$ref" : "#/components/schemas/FieldStyle",
+              "readOnly" : false
+            },
+            "untagOnResolve" : {
+              "type" : "boolean",
+              "readOnly" : false
+            },
+            "visibleFor" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "updateableBy" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "readSharingSettings" : {
+              "$ref" : "#/components/schemas/WatchFolderSharingSettings",
+              "readOnly" : true
+            },
+            "tagSharingSettings" : {
+              "$ref" : "#/components/schemas/TagSharingSettings",
+              "readOnly" : true
+            },
+            "updateSharingSettings" : {
+              "$ref" : "#/components/schemas/WatchFolderSharingSettings",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "TagSharingSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "permittedGroups" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/UserGroup"
+            }
+          },
+          "permittedUsers" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/User"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Stores users and groups that have access to a tag.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "TagsActivityItem" : {
+        "description" : "Represents a change in the list of tags of an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/MultiValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Tag"
+              }
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/Tag"
+              }
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/Issue",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "TeamcityChangesProcessor" : {
+        "description" : "Represents a TeamCity integration configured for a project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/TeamcityServer",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "TeamcityServer" : {
+        "description" : "Represents a TeamCity server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "Telemetry" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "installationFolder" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "databaseLocation" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "logsLocation" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "availableProcessors" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "availableMemory" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "allocatedMemory" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "usedMemory" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "uptime" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "startedTime" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "databaseBackgroundThreads" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "pendingAsyncJobs" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "cachedResultsCountInDBQueriesCache" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "databaseQueriesCacheHitRate" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "blobStringsCacheHitRate" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "totalTransactions" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "transactionsPerSecond" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "requestsPerSecond" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "databaseSize" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "fullDatabaseSize" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "textIndexSize" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "onlineUsers" : {
+            "$ref" : "#/components/schemas/OnlineUsers",
+            "readOnly" : true
+          },
+          "reportCalculatorThreads" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "notificationAnalyzerThreads" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "TextCustomFieldActivityItem" : {
+        "description" : "Represents an activity that affects a custom field of the `text` type of an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CustomFieldActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "markup" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/Issue",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "TextFieldValue" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "markdownText" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a value of the text field. Returns both source and rendered text.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "TextIssueCustomField" : {
+        "description" : "Represents the issue custom field of the `text` type.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IssueCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "value" : {
+              "$ref" : "#/components/schemas/TextFieldValue",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "TextMarkupActivityItem" : {
+        "description" : "Represents a change in a `String`-type attribute with the support of markup:\n`description` in an Issue or IssueWorkItem, and the `text` of the IssueComment.\nThis entity lets you get the rendered text after the change.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SimpleValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "markup" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "TextProjectCustomField" : {
+        "description" : "Represents settings of the text-type field in the project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SimpleProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "TimeTrackingUserProfile" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "periodFormat" : {
+            "$ref" : "#/components/schemas/PeriodFieldFormat",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "TimeZoneDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "presentation" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "offset" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a time zone.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "UnlimitedVisibility" : {
+        "description" : "Represents unlimited visibility. When access to an entity is not restricted, the visibility attribute of this entity has the type `UnlimitedVisibility`. Entities of this type do not have any attributes.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Visibility"
+        } ]
+      },
+      "User" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "login" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "fullName" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "email" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "ringId" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "guest" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "online" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "banned" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "banBadge" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "banReason" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "isAnonymized" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "tags" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/Tag"
+            }
+          },
+          "savedQueries" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/SavedQuery"
+            }
+          },
+          "avatarUrl" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "profiles" : {
+            "$ref" : "#/components/schemas/UserProfiles",
+            "readOnly" : true
+          },
+          "userType" : {
+            "$ref" : "#/components/schemas/UserType",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "User" : "#/components/schemas/User",
+            "VcsUnresolvedUser" : "#/components/schemas/VcsUnresolvedUser",
+            "Me" : "#/components/schemas/Me"
+          }
+        }
+      },
+      "UserBundle" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Bundle"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "groups" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            },
+            "individuals" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            },
+            "aggregatedUsers" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        } ]
+      },
+      "UserCustomFieldDefaults" : {
+        "description" : "Represents default settings for the user-type field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CustomFieldDefaults"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/UserBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        } ]
+      },
+      "UserGroup" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "ringId" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "usersCount" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "icon" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "allUsersGroup" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "users" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/User"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "UserGroup" : "#/components/schemas/UserGroup",
+            "AllUsersGroup" : "#/components/schemas/AllUsersGroup",
+            "RegisteredUsersGroup" : "#/components/schemas/RegisteredUsersGroup",
+            "ProjectTeam" : "#/components/schemas/ProjectTeam",
+            "NestedGroup" : "#/components/schemas/NestedGroup"
+          }
+        }
+      },
+      "UserProfiles" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "general" : {
+            "$ref" : "#/components/schemas/GeneralUserProfile",
+            "readOnly" : true
+          },
+          "notifications" : {
+            "$ref" : "#/components/schemas/NotificationsUserProfile",
+            "readOnly" : true
+          },
+          "timetracking" : {
+            "$ref" : "#/components/schemas/TimeTrackingUserProfile",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a group of settings of a user profile in YouTrack.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "UserProjectCustomField" : {
+        "description" : "Represents project settings for a user field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/UserBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            }
+          }
+        } ]
+      },
+      "UserType" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "The type of the user.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "UsesMarkupActivityItem" : {
+        "description" : "Represents the change of the boolean flag that indicates whether YouTrack Wiki or Markdown\nis used in the target entity as a markup language. If `true`, then the markdown is used.\nOtherwise, YouTrack Wiki markup.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SimpleValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "boolean",
+              "readOnly" : true
+            },
+            "markup" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "boolean",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "VcsChange" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "date" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "fetched" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "files" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "author" : {
+            "$ref" : "#/components/schemas/User",
+            "readOnly" : true
+          },
+          "processors" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/ChangesProcessor"
+            }
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "urls" : {
+            "type" : "array",
+            "readOnly" : true,
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "version" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "issue" : {
+            "$ref" : "#/components/schemas/Issue",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "state" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "VcsChangeActivityItem" : {
+        "description" : "Represents an update in the list of VCS changes of an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CreatedDeletedActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/VcsChange"
+              }
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/VcsChange"
+              }
+            },
+            "author" : {
+              "$ref" : "#/components/schemas/User",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "VcsHostingChangesProcessor" : {
+        "description" : "The basic entity that represents a VCS integration configured for a project.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ChangesProcessor"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "server" : {
+              "$ref" : "#/components/schemas/VcsHostingServer",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "path" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "branchSpecification" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "committers" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "VcsHostingServer" : {
+        "description" : "The basic entity that represents a VCS server.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VcsServer"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "url" : {
+              "type" : "string",
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "VcsServer" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "url" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "The basic entity that represents a VCS or a build server.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "VcsServer" : "#/components/schemas/VcsServer",
+            "JenkinsServer" : "#/components/schemas/JenkinsServer",
+            "VcsHostingServer" : "#/components/schemas/VcsHostingServer",
+            "GogsServer" : "#/components/schemas/GogsServer",
+            "GiteaServer" : "#/components/schemas/GiteaServer",
+            "SpaceServer" : "#/components/schemas/SpaceServer",
+            "GitHubServer" : "#/components/schemas/GitHubServer",
+            "GitLabServer" : "#/components/schemas/GitLabServer",
+            "BitBucketServer" : "#/components/schemas/BitBucketServer",
+            "BitbucketStandaloneServer" : "#/components/schemas/BitbucketStandaloneServer",
+            "TeamcityServer" : "#/components/schemas/TeamcityServer"
+          }
+        }
+      },
+      "VcsUnresolvedUser" : {
+        "description" : "Represents a VCS change author who could not be associated with any YouTrack user account.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/User"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "name" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "VersionBundle" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BaseBundle"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "values" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/VersionBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "VersionBundleCustomFieldDefaults" : {
+        "description" : "Default settings for the version-type field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleCustomFieldDefaults"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/VersionBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/VersionBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "VersionBundleElement" : {
+        "description" : "",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleElement"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "archived" : {
+              "type" : "boolean",
+              "readOnly" : false
+            },
+            "released" : {
+              "type" : "boolean",
+              "readOnly" : false
+            },
+            "releaseDate" : {
+              "type" : "integer",
+              "format" : "int64",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "startDate" : {
+              "type" : "integer",
+              "format" : "int64",
+              "nullable" : true,
+              "readOnly" : false
+            }
+          }
+        } ]
+      },
+      "VersionProjectCustomField" : {
+        "description" : "Represents project settings for a version field.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BundleProjectCustomField"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "bundle" : {
+              "$ref" : "#/components/schemas/VersionBundle",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "defaultValues" : {
+              "type" : "array",
+              "readOnly" : false,
+              "items" : {
+                "$ref" : "#/components/schemas/VersionBundleElement"
+              }
+            }
+          }
+        } ]
+      },
+      "Visibility" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents visibility settings of an entity, for example, an issue or a comment.",
+        "discriminator" : {
+          "propertyName" : "$type",
+          "mapping" : {
+            "Visibility" : "#/components/schemas/Visibility",
+            "UnlimitedVisibility" : "#/components/schemas/UnlimitedVisibility",
+            "LimitedVisibility" : "#/components/schemas/LimitedVisibility"
+          }
+        }
+      },
+      "VisibilityActivityItem" : {
+        "description" : "Represents the changes of properties responsible for visibility restriction.\nCan be <a href=\"api-entity-VisibilityGroupActivityItem.topic\">VisibilityGroupActivityItem</a> or <a href=\"api-entity-VisibilityUserActivityItem.topic\">VisibilityUserActivityItem</a>",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/MultiValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "targetMember" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "targetSubMember" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "VisibilityGroupActivityItem" : {
+        "description" : "Represents the event when a user adds or removes a group to/from the Visibility settings of the target entity.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VisibilityActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/UserGroup"
+              }
+            },
+            "targetMember" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "targetSubMember" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "VisibilityUserActivityItem" : {
+        "description" : "Represents the event when a user adds or removes a user to/from the Visibility settings of the target entity.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/VisibilityActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            },
+            "targetMember" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "targetSubMember" : {
+              "type" : "string",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "VotersActivityItem" : {
+        "description" : "Represents a change in the list of voters of an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/MultiValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/User"
+              }
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/Issue",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "WIPLimit" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "max" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "min" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "column" : {
+            "$ref" : "#/components/schemas/AgileColumn",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents WIP limits for particular column. If they are not satisfied, the column will be highlighted in UI.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "WatchFolder" : {
+        "description" : "`WatchFolder` is a common abstract ancestor for saved searches and tags.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IssueFolder"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "owner" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "visibleFor" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "updateableBy" : {
+              "$ref" : "#/components/schemas/UserGroup",
+              "nullable" : true,
+              "readOnly" : false
+            },
+            "readSharingSettings" : {
+              "$ref" : "#/components/schemas/WatchFolderSharingSettings",
+              "readOnly" : true
+            },
+            "updateSharingSettings" : {
+              "$ref" : "#/components/schemas/WatchFolderSharingSettings",
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "WatchFolderSharingSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "permittedGroups" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/UserGroup"
+            }
+          },
+          "permittedUsers" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/User"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Stores users and groups that have access to a tag or a saved search.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "WorkItemActivityItem" : {
+        "description" : "Represents a change in a list of work items in an issue.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/CreatedDeletedActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/IssueWorkItem",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/IssueWorkItem"
+              }
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/IssueWorkItem"
+              }
+            }
+          }
+        } ]
+      },
+      "WorkItemAttribute" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "workItem" : {
+            "$ref" : "#/components/schemas/BaseWorkItem",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "projectAttribute" : {
+            "$ref" : "#/components/schemas/WorkItemProjectAttribute",
+            "readOnly" : true
+          },
+          "value" : {
+            "$ref" : "#/components/schemas/WorkItemAttributeValue",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the attribute of a specific work item.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "WorkItemAttributePrototype" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "instances" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/WorkItemProjectAttribute"
+            }
+          },
+          "values" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/WorkItemAttributeValue"
+            }
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a work item attribute prototype that is common for all projects. The project-related settings for work item attributes are stored in the `WorkItemProjectAttribute` entities.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "WorkItemAttributeValue" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "description" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "autoAttach" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "prototype" : {
+            "$ref" : "#/components/schemas/WorkItemAttributePrototype",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents a value of a work item attribute.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "WorkItemAuthorActivityItem" : {
+        "description" : "Represents a change in the `author` attribute of a work item.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SingleValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/IssueWorkItem",
+              "readOnly" : true
+            },
+            "removed" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "added" : {
+              "$ref" : "#/components/schemas/User",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "WorkItemDurationActivityItem" : {
+        "description" : "Represents a change in the `duration` attribute of a work item.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SingleValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/IssueWorkItem",
+              "readOnly" : true
+            },
+            "removed" : {
+              "$ref" : "#/components/schemas/DurationValue",
+              "nullable" : true,
+              "readOnly" : true
+            },
+            "added" : {
+              "$ref" : "#/components/schemas/DurationValue",
+              "nullable" : true,
+              "readOnly" : true
+            }
+          }
+        } ]
+      },
+      "WorkItemProjectAttribute" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "timeTrackingSettings" : {
+            "$ref" : "#/components/schemas/ProjectTimeTrackingSettings",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "prototype" : {
+            "$ref" : "#/components/schemas/WorkItemAttributePrototype",
+            "nullable" : true,
+            "readOnly" : false
+          },
+          "values" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "$ref" : "#/components/schemas/WorkItemAttributeValue"
+            }
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "ordinal" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "Represents the project-related settings of a work item attribute.",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "WorkItemType" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "name" : {
+            "type" : "string",
+            "readOnly" : false
+          },
+          "autoAttached" : {
+            "type" : "boolean",
+            "readOnly" : false
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      },
+      "WorkItemTypeActivityItem" : {
+        "description" : "Represents a change in the `type` attribute of the work item.",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/MultiValueActivityItem"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "readOnly" : true
+            },
+            "target" : {
+              "$ref" : "#/components/schemas/IssueWorkItem",
+              "readOnly" : true
+            },
+            "removed" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/WorkItemType"
+              }
+            },
+            "added" : {
+              "type" : "array",
+              "readOnly" : true,
+              "items" : {
+                "$ref" : "#/components/schemas/WorkItemType"
+              }
+            }
+          }
+        } ]
+      },
+      "WorkTimeSettings" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "minutesADay" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : false
+          },
+          "workDays" : {
+            "type" : "array",
+            "readOnly" : false,
+            "items" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
+          "firstDayOfWeek" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "daysAWeek" : {
+            "type" : "integer",
+            "format" : "int32",
+            "readOnly" : true
+          },
+          "$type" : {
+            "type" : "string",
+            "readOnly" : true
+          }
+        },
+        "description" : "",
+        "discriminator" : {
+          "propertyName" : "$type"
+        }
+      }
+    },
+    "securitySchemes" : {
+      "permanentToken" : {
+        "type" : "http",
+        "scheme" : "bearer",
+        "bearerFormat" : "YouTrack permanent token"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Running the generator against real-world specs (the public [YouTrack OpenAPI spec](https://youtrack.jetbrains.com/api/openapi.json)) produces **non-compiling** code. This continues the inheritance work from #512 and the compile-test infra from #511.

Three distinct defects, all reproduced by that spec:

1. **Kotlin — duplicate inherited constructor properties.** Deep `allOf` chains that re-declare an inherited property at several levels (e.g. `ActivityItem → MultiValueActivityItem → WorkItemTypeActivityItem`, which restate `id`/`added`/`removed`) generated the same `override val` — and the same super-constructor argument — two or three times. ~120 of 242 generated DTOs failed to compile.

2. **Java — clashing Lombok accessors.** A subclass that re-declares an inherited property with a *narrower* type (`BuildBundle.values: List<BuildBundleElement>` vs `BaseBundle.values: List<BundleElement>`) made Lombok emit a getter that cannot override the inherited one, plus a setter that clashes on erasure.

3. **Both — illegal parameter identifiers.** The multipart field literally named `files[0]` was emitted verbatim as a parameter identifier. Kotlin produced `Name contains illegal characters: []`; JavaPoet threw at generation time.

## Fix

- `KotlinTypeDefiner`: `constructorPropertiesOf` de-duplicates inherited properties by key (first/most-base wins, so parameter order stays aligned with the base constructor); a subclass no longer re-emits an own property already declared as an inherited `override`.
- `JavaTypeDefiner`: resolves ancestor property keys through the `allOf` chain and skips re-declaring them, reusing the inherited field and Lombok accessors.
- `CaseUtils.toIdentifier`: strips characters illegal in an identifier (even back-ticked); the binding annotation keeps the original wire name (`name = "files[0]"`), so serialization is unchanged. Applied at all parameter sites in both API extractors.

### Note on the Java narrowing case
Where a child narrowed an inherited property's type, the generated getter now returns the parent's (wider) type — the narrowing is dropped so the code compiles. This is the type-safe choice; preserving narrowing would need covariant getter overrides, a larger change. Happy to revisit if you'd prefer that.

## Tests
- `youtrackOpenapiCompiles` (Kotlin + Java): generate all ~242 files from the full spec and compile them. Compile-only (no snapshot for 200+ files).
- `inheritedRootProperty` (Kotlin + Java): the maintainer's exact example from #233 — snapshot + compile.
- `CaseUtils.toIdentifier`: unit cases.

All 85 tests pass; checkstyle clean.

### Heads-up on the fixture
`src/test/resources/youtrack_openapi.json` is the real 564 KB spec, vendored so the regression is faithful and offline-stable. If you'd rather not carry a file that size, I can replace it with a small synthetic spec that reproduces all three defects — your call.

---

🤖 This PR was prepared with the assistance of [Claude Code](https://claude.com/claude-code). All changes were reviewed and verified (tests + checkstyle green) before submission.