### PR TITLE
feat: framework (Spring/Quarkus) and role (server/client) selectors for code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ codegen.generate(yamlPath, resultPath)
 |`generateApiInterface`|boolean|false|Set to true if you need to generate an interface called `Api` besides `Controller`. `Api` methods do not have `HttpServletResponse` parameter.
 |`forceSnakeCaseForProperties`|boolean|true|By default, hurdy-gurdy expects all the properties of DTO classes to be defined in _snake_case_ in the specification. It converts these names to _camelCase_ for generated classes and sets Jackson's `SnakeCaseStrategy` so that they will still be _snake_case_ in JSON representation. If you don't want this (e. g. if you want your properties to be defined in _camelCase_ everywhere) you can turn off this function via this parameter. 
 |`framework`|String (`spring`\|`quarkus`)|`spring`|Selects the web framework whose annotations are emitted on the generated `Controller`/`Api` interfaces. `spring` (default) emits Spring MVC annotations (`@GetMapping`, `@PathVariable`, …). `quarkus` emits Jakarta REST / Quarkus annotations (`@GET` + `@Path`, `@PathParam`, `@QueryParam`, `@HeaderParam`, `@RestForm` for multipart). Value is case-insensitive.|
+|`role`|String (`server`\|`client`)|`server`|Selects whether the generated interfaces are server resources (to implement) or client interfaces (whose implementation the framework provides). `client` emits, for Spring, Spring 6 HTTP Interface annotations (`@GetExchange`, …) used via `HttpServiceProxyFactory`; for Quarkus, a `@RegisterRestClient` interface injected with `@RestClient`. Case-insensitive.|
 
 ## Quarkus (Jakarta REST) output
 
@@ -92,6 +93,22 @@ The generated Quarkus code requires `jakarta.ws.rs-api` on the consuming project
 classpath. For multipart endpoints, it also requires `org.jboss.resteasy.reactive.RestForm`
 and `org.jboss.resteasy.reactive.multipart.FileUpload` — both provided by the
 Quarkus REST extension.
+
+## Client generation (`role=client`)
+
+With `role=client` the generated interfaces are meant to be *called*, not implemented — the
+framework supplies the implementation.
+
+- **Spring** (`framework=spring`): Spring 6 HTTP Interface. Methods carry `@GetExchange`/`@PostExchange`/
+  `@PutExchange`/`@PatchExchange`/`@DeleteExchange`; parameters keep the same `@PathVariable`/`@RequestParam`/
+  `@RequestHeader`/`@RequestBody`/`@RequestPart` annotations. Create a proxy with `HttpServiceProxyFactory`.
+- **Quarkus** (`framework=quarkus`): the interface is additionally annotated `@RegisterRestClient`; inject it
+  with `@RestClient`. No implementation is written.
+
+`generateResponseParameter=true` makes client methods return the HTTP envelope so callers can inspect
+status/headers: `ResponseEntity<T>` (Spring) / `jakarta.ws.rs.core.Response` (Quarkus). With
+`generateResponseParameter=false` they return the deserialized DTO. Server-only constructs
+(`HttpServletResponse`, `@Context ContainerRequestContext`, `x-include-request`) are omitted in client mode.
 
 ## Inheritance hierarchy compatible with openapi-codegen
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,17 @@ Annotation mapping:
 | Request body | `@RequestBody` | *(unannotated parameter)* |
 | Multipart part | `@RequestPart` | `@RestForm` |
 
+`@Produces` is emitted only when the operation defines a success (2xx) response
+media type, and `@Consumes` only when the request body defines a media type.
+
 `generateResponseParameter` has no servlet analog in Quarkus. When enabled, the
 generated method returns `jakarta.ws.rs.core.Response` (instead of the DTO), and
 a Javadoc/KDoc `@return` line documents the entity type the `Response` is
-expected to carry. The `x-include-request: true` operation extension adds a
-`@Context jakarta.ws.rs.container.ContainerRequestContext requestContext`
-parameter instead of `HttpServletRequest`.
+expected to carry. When `generateResponseParameter` is true and the
+`x-include-request: true` operation extension is present, the generated method
+also gains a `@Context jakarta.ws.rs.container.ContainerRequestContext
+requestContext` parameter (the Quarkus analog of the Spring `HttpServletRequest`
+behavior).
 
 The generated Quarkus code requires `jakarta.ws.rs-api` on the consuming project's
 classpath. For multipart endpoints, it also requires `org.jboss.resteasy.reactive.RestForm`

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Generates client and server side Java/Kotlin code based on OpenAPI spec, using [
         Set to false (default) if you don't need one 
         (good for client-side)-->
         <generateResponseParameter>true</generateResponseParameter>
+        <!--Optional: target web framework (spring|quarkus, default spring)
+        and which interfaces to generate (any subset of controller,api,client;
+        default controller) — see "Generated interfaces" below-->
+        <framework>spring</framework>
+        <generate>controller,client</generate>
     </configuration>
     <executions>
         <execution>
@@ -37,10 +42,19 @@ Generates client and server side Java/Kotlin code based on OpenAPI spec, using [
 ## Usage example (in Kotlin code, e.g. Gradle's buildSrc)
 
 ```kotlin
-import ru.curs.hurdygurdy.KotlinCodegen
+import ru.curs.hurdygurdy.Framework
 import ru.curs.hurdygurdy.GeneratorParams
+import ru.curs.hurdygurdy.KotlinCodegen
+import ru.curs.hurdygurdy.Role
 
-val codegen = KotlinCodegen(GeneratorParams.rootPackage("com.example.project"))
+val codegen = KotlinCodegen(
+    GeneratorParams.rootPackage("com.example.project")
+        // optional: spring is the default
+        .framework(Framework.QUARKUS)
+        // optional: controller alone is the default;
+        // a Kotlin collection works too: .generate(listOf(Role.CONTROLLER, Role.CLIENT))
+        .generate(Role.CONTROLLER, Role.CLIENT)
+)
 val yamlPath = project.layout.projectDirectory.asFile.toPath().resolve("src/main/openapi/api.yaml")
 val resultPath = project.layout.buildDirectory.get().asFile.toPath().resolve("generated-sources")
 Files.createDirectories(resultPath)
@@ -51,12 +65,42 @@ codegen.generate(yamlPath, resultPath)
 
 | Parameter name | Type | Default value | Description |
 |--------------------------|------|---------------|-------------|
-|`rootPackage`|String | | Sets the root package for all the generated classes. `Controller` and `Api` interfaces will be generated in `controller` subpackage, and all the DTOs will be generated in `dto` subpackage.
-|`generateResponseParameter`|boolean|false|Set to true if you need to have `HttpServletResponse` parameter in each generated `Controller` method. You might need this in order to return specific HTTP status codes. When used together with the operation-level extension `x-include-request: true`, the generated method will also include `jakarta.servlet.http.HttpServletRequest request` parameter.
-|`generateApiInterface`|boolean|false|Set to true if you need to generate an interface called `Api` besides `Controller`. `Api` methods do not have `HttpServletResponse` parameter.
+|`rootPackage`|String | | Sets the root package for all the generated classes. `Controller`, `Api` and `Client` interfaces will be generated in `controller` subpackage, and all the DTOs will be generated in `dto` subpackage.
+|`generateResponseParameter`|boolean|false|Set to true if you need access to the raw HTTP response. For `controller`: adds an `HttpServletResponse` parameter to each method (Spring) or makes methods return `jakarta.ws.rs.core.Response` (Quarkus) — useful for returning specific HTTP status codes; together with the operation-level extension `x-include-request: true`, the method also receives the request. For `client`: methods return the HTTP envelope (`ResponseEntity<T>` for Spring, `Response` for Quarkus). Never affects `api` interfaces.
+|`generateApiInterface`|boolean|false|**Deprecated** — equivalent to adding `api` to `generate` (see below). Kept for backwards compatibility.
 |`forceSnakeCaseForProperties`|boolean|true|By default, hurdy-gurdy expects all the properties of DTO classes to be defined in _snake_case_ in the specification. It converts these names to _camelCase_ for generated classes and sets Jackson's `SnakeCaseStrategy` so that they will still be _snake_case_ in JSON representation. If you don't want this (e. g. if you want your properties to be defined in _camelCase_ everywhere) you can turn off this function via this parameter. 
-|`framework`|String (`spring`\|`quarkus`)|`spring`|Selects the web framework whose annotations are emitted on the generated `Controller`/`Api` interfaces. `spring` (default) emits Spring MVC annotations (`@GetMapping`, `@PathVariable`, …). `quarkus` emits Jakarta REST / Quarkus annotations (`@GET` + `@Path`, `@PathParam`, `@QueryParam`, `@HeaderParam`, `@RestForm` for multipart). Value is case-insensitive.|
-|`role`|String (`server`\|`client`)|`server`|Selects whether the generated interfaces are server resources (to implement) or client interfaces (whose implementation the framework provides). `client` emits, for Spring, Spring 6 HTTP Interface annotations (`@GetExchange`, …) used via `HttpServiceProxyFactory`; for Quarkus, a `@RegisterRestClient` interface injected with `@RestClient`. Case-insensitive.|
+|`framework`|String (`spring`\|`quarkus`)|`spring`|Selects the web framework whose annotations are emitted on the generated interfaces. `spring` (default) emits Spring MVC annotations (`@GetMapping`, `@PathVariable`, …). `quarkus` emits Jakarta REST / Quarkus annotations (`@GET` + `@Path`, `@PathParam`, `@QueryParam`, `@HeaderParam`, `@RestForm` for multipart). Value is case-insensitive.|
+|`generate`|comma-separated subset of `controller`, `api`, `client`|`controller`|Selects which interfaces to generate — any combination in a single run, e.g. `<generate>controller,client</generate>`. See [Generated interfaces](#generated-interfaces-generate). Case-insensitive.|
+
+## Generated interfaces (`generate`)
+
+The `generate` parameter selects which interfaces are emitted for the API paths — any
+subset of `controller`, `api` and `client`, in a single run, all in the `controller`
+subpackage and sharing the same DTOs. Combined with `framework`, this gives six
+possible artifacts:
+
+| `generate` value | `framework=spring` | `framework=quarkus` |
+|---|---|---|
+| `controller` | `XxxController` — server interface to implement: `@GetMapping`, …; optional `HttpServletResponse` parameter | `XxxController` — Jakarta REST resource interface to implement: `@GET` + `@Path`, …; optional `Response` return type |
+| `api` | `XxxApi` — pure contract: same Spring MVC annotations, no response-related artifacts. Directly consumable by [Spring Cloud OpenFeign](https://spring.io/projects/spring-cloud-openfeign) (its default `SpringMvcContract` parses `@GetMapping`/`@RequestMapping` on [OpenFeign](https://github.com/OpenFeign/feign) client interfaces), or as a typed contract for hand-written implementations, e.g. over [REST Assured](https://rest-assured.io/) in tests | `XxxApi` — pure contract: same Jakarta REST annotations, no response-related artifacts. Directly consumable by [MicroProfile REST Client](https://github.com/eclipse/microprofile-rest-client)'s `RestClientBuilder.newBuilder().baseUri(…).build(XxxApi.class)` (no `@RegisterRestClient` needed for the programmatic API), or as a typed contract for hand-written implementations |
+| `client` | `XxxClient` — [Spring 6 HTTP Interface](https://docs.spring.io/spring-framework/reference/integration/rest-clients.html#rest-http-interface): `@GetExchange`, …; create a proxy with `HttpServiceProxyFactory` | `XxxClient` — [MicroProfile / Quarkus REST Client](https://quarkus.io/guides/rest-client): `@RegisterRestClient` interface, inject it with `@RestClient` |
+
+For example, a Quarkus service that also calls itself from tests (or a sibling service
+consuming the same spec) can generate both sides at once:
+
+```xml
+<framework>quarkus</framework>
+<generate>controller,client</generate>
+```
+
+`generateResponseParameter` applies per interface kind: it affects `controller`
+(response parameter / `Response` return) and `client` (methods return the HTTP
+envelope — `ResponseEntity<T>` for Spring, `Response` for Quarkus — so callers can
+inspect status and headers), and never affects `api`. Server-only constructs
+(`HttpServletResponse`, `@Context ContainerRequestContext`, `x-include-request`)
+are omitted from `api` and `client` interfaces.
+
+In code, use `GeneratorParams.rootPackage(...).generate(Role.CONTROLLER, Role.CLIENT)`.
 
 ## Quarkus (Jakarta REST) output
 
@@ -81,11 +125,11 @@ Annotation mapping:
 media type, and `@Consumes` only when the request body defines a media type.
 
 `generateResponseParameter` has no servlet analog in Quarkus. When enabled, the
-generated method returns `jakarta.ws.rs.core.Response` (instead of the DTO), and
-a Javadoc/KDoc `@return` line documents the entity type the `Response` is
+generated `Controller` method returns `jakarta.ws.rs.core.Response` (instead of the
+DTO), and a Javadoc/KDoc `@return` line documents the entity type the `Response` is
 expected to carry. When `generateResponseParameter` is true and the
-`x-include-request: true` operation extension is present, the generated method
-also gains a `@Context jakarta.ws.rs.container.ContainerRequestContext
+`x-include-request: true` operation extension is present, the generated `Controller`
+method also gains a `@Context jakarta.ws.rs.container.ContainerRequestContext
 requestContext` parameter (the Quarkus analog of the Spring `HttpServletRequest`
 behavior).
 
@@ -94,21 +138,23 @@ classpath. For multipart endpoints, it also requires `org.jboss.resteasy.reactiv
 and `org.jboss.resteasy.reactive.multipart.FileUpload` — both provided by the
 Quarkus REST extension.
 
-## Client generation (`role=client`)
+## Client generation (`generate=client`)
 
-With `role=client` the generated interfaces are meant to be *called*, not implemented — the
-framework supplies the implementation.
+With `client` in the `generate` set, the emitted `XxxClient` interfaces are meant to be
+*called*, not implemented — the framework supplies the implementation.
 
-- **Spring** (`framework=spring`): Spring 6 HTTP Interface. Methods carry `@GetExchange`/`@PostExchange`/
-  `@PutExchange`/`@PatchExchange`/`@DeleteExchange`; parameters keep the same `@PathVariable`/`@RequestParam`/
-  `@RequestHeader`/`@RequestBody`/`@RequestPart` annotations. Create a proxy with `HttpServiceProxyFactory`.
+- **Spring** (`framework=spring`): [Spring 6 HTTP Interface](https://docs.spring.io/spring-framework/reference/integration/rest-clients.html#rest-http-interface).
+  Methods carry `@GetExchange`/`@PostExchange`/`@PutExchange`/`@PatchExchange`/`@DeleteExchange`;
+  parameters keep the same `@PathVariable`/`@RequestParam`/`@RequestHeader`/`@RequestBody`/`@RequestPart`
+  annotations. Create a proxy with `HttpServiceProxyFactory`.
 - **Quarkus** (`framework=quarkus`): the interface is additionally annotated `@RegisterRestClient`; inject it
-  with `@RestClient`. No implementation is written.
+  with `@RestClient`. No implementation is written. See the [Quarkus REST Client guide](https://quarkus.io/guides/rest-client).
 
 `generateResponseParameter=true` makes client methods return the HTTP envelope so callers can inspect
 status/headers: `ResponseEntity<T>` (Spring) / `jakarta.ws.rs.core.Response` (Quarkus). With
 `generateResponseParameter=false` they return the deserialized DTO. Server-only constructs
-(`HttpServletResponse`, `@Context ContainerRequestContext`, `x-include-request`) are omitted in client mode.
+(`HttpServletResponse`, `@Context ContainerRequestContext`, `x-include-request`) are omitted from client
+interfaces.
 
 ## Inheritance hierarchy compatible with openapi-codegen
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,38 @@ codegen.generate(yamlPath, resultPath)
 |`generateResponseParameter`|boolean|false|Set to true if you need to have `HttpServletResponse` parameter in each generated `Controller` method. You might need this in order to return specific HTTP status codes. When used together with the operation-level extension `x-include-request: true`, the generated method will also include `jakarta.servlet.http.HttpServletRequest request` parameter.
 |`generateApiInterface`|boolean|false|Set to true if you need to generate an interface called `Api` besides `Controller`. `Api` methods do not have `HttpServletResponse` parameter.
 |`forceSnakeCaseForProperties`|boolean|true|By default, hurdy-gurdy expects all the properties of DTO classes to be defined in _snake_case_ in the specification. It converts these names to _camelCase_ for generated classes and sets Jackson's `SnakeCaseStrategy` so that they will still be _snake_case_ in JSON representation. If you don't want this (e. g. if you want your properties to be defined in _camelCase_ everywhere) you can turn off this function via this parameter. 
+|`framework`|String (`spring`\|`quarkus`)|`spring`|Selects the web framework whose annotations are emitted on the generated `Controller`/`Api` interfaces. `spring` (default) emits Spring MVC annotations (`@GetMapping`, `@PathVariable`, …). `quarkus` emits Jakarta REST / Quarkus annotations (`@GET` + `@Path`, `@PathParam`, `@QueryParam`, `@HeaderParam`, `@RestForm` for multipart). Value is case-insensitive.|
+
+## Quarkus (Jakarta REST) output
+
+Set `framework` to `quarkus` (Maven `<framework>quarkus</framework>`, or
+`GeneratorParams.rootPackage(...).framework(Framework.QUARKUS)` in code) to
+generate Jakarta REST interfaces instead of Spring MVC ones. DTO classes are
+identical in both modes.
+
+Annotation mapping:
+
+| Concern | Spring | Quarkus (JAX-RS) |
+|---------|--------|------------------|
+| Interface | *(none)* | `@Path("")` |
+| HTTP method | `@GetMapping(value, produces, consumes)` | `@GET` + `@Path(path)` + `@Produces` + `@Consumes` |
+| Path parameter | `@PathVariable` | `@PathParam` |
+| Query parameter | `@RequestParam` | `@QueryParam` (+ `@DefaultValue`) |
+| Header parameter | `@RequestHeader` | `@HeaderParam` |
+| Request body | `@RequestBody` | *(unannotated parameter)* |
+| Multipart part | `@RequestPart` | `@RestForm` |
+
+`generateResponseParameter` has no servlet analog in Quarkus. When enabled, the
+generated method returns `jakarta.ws.rs.core.Response` (instead of the DTO), and
+a Javadoc/KDoc `@return` line documents the entity type the `Response` is
+expected to carry. The `x-include-request: true` operation extension adds a
+`@Context jakarta.ws.rs.container.ContainerRequestContext requestContext`
+parameter instead of `HttpServletRequest`.
+
+The generated Quarkus code requires `jakarta.ws.rs-api` on the consuming project's
+classpath. For multipart endpoints, it also requires `org.jboss.resteasy.reactive.RestForm`
+and `org.jboss.resteasy.reactive.multipart.FileUpload` — both provided by the
+Quarkus REST extension.
 
 ## Inheritance hierarchy compatible with openapi-codegen
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
         </dependency>
         <!-- test -->
         <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.curs</groupId>
     <artifactId>hurdy-gurdy</artifactId>
-    <version>2.10</version>
+    <version>2.11-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>OpenAPI codegen Maven Plugin</name>

--- a/src/main/java/ru/curs/hurdygurdy/APIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/APIExtractor.java
@@ -46,6 +46,10 @@ public abstract class APIExtractor<T, B> implements TypeSpecExtractor<T> {
         return params.getFramework();
     }
 
+    protected Role getRole() {
+        return params.getRole();
+    }
+
     public final void extractTypeSpecs(OpenAPI openAPI, BiConsumer<ClassCategory, T> typeSpecBiConsumer) {
         Paths paths = openAPI.getPaths();
         if (paths == null) return;

--- a/src/main/java/ru/curs/hurdygurdy/APIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/APIExtractor.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -25,12 +26,12 @@ public abstract class APIExtractor<T, B> implements TypeSpecExtractor<T> {
     private final GeneratorParams params;
 
     private final Map<String, B> builders = new HashMap<>();
-    private final Function<String, B> builderSupplier;
+    private final BiFunction<String, Role, B> builderSupplier;
     private final Function<B, T> buildInvoker;
 
     protected APIExtractor(TypeDefiner<T> typeDefiner,
                            GeneratorParams params,
-                           Function<String, B> builderSupplier,
+                           BiFunction<String, Role, B> builderSupplier,
                            Function<B, T> buildInvoker) {
         this.typeDefiner = typeDefiner;
         this.params = params;
@@ -38,46 +39,41 @@ public abstract class APIExtractor<T, B> implements TypeSpecExtractor<T> {
         this.buildInvoker = buildInvoker;
     }
 
-    private B builder(String className) {
-        return builders.computeIfAbsent(className, k -> builderSupplier.apply(className));
+    private B builder(String className, Role role) {
+        return builders.computeIfAbsent(className, k -> builderSupplier.apply(className, role));
     }
 
     protected Framework getFramework() {
         return params.getFramework();
     }
 
-    protected Role getRole() {
-        return params.getRole();
-    }
-
     public final void extractTypeSpecs(OpenAPI openAPI, BiConsumer<ClassCategory, T> typeSpecBiConsumer) {
         Paths paths = openAPI.getPaths();
         if (paths == null) return;
-        generateClass(openAPI, paths, "Controller", params.isGenerateResponseParameter());
-        builders.values().stream().map(buildInvoker).forEach(t ->
-                typeSpecBiConsumer.accept(ClassCategory.CONTROLLER, t));
-        if (params.isGenerateApiInterface()) {
+        for (Role role : params.getGenerate()) {
             builders.clear();
-            generateClass(openAPI, paths, "Api", false);
+            //the Api interface never carries response-related artifacts
+            generateClass(openAPI, paths, role,
+                    role != Role.API && params.isGenerateResponseParameter());
             builders.values().stream().map(buildInvoker).forEach(t ->
                     typeSpecBiConsumer.accept(ClassCategory.CONTROLLER, t));
         }
     }
 
-    private void generateClass(OpenAPI openAPI, Paths paths, String name, boolean responseParameter) {
+    private void generateClass(OpenAPI openAPI, Paths paths, Role role, boolean responseParameter) {
         for (Map.Entry<String, PathItem> stringPathItemEntry : paths.entrySet()) {
             for (Map.Entry<PathItem.HttpMethod, Operation> operationEntry
                     : stringPathItemEntry.getValue().readOperationsMap().entrySet()) {
                 List<String> tags = operationEntry.getValue().getTags();
                 String typeName = CaseUtils.snakeToCamel(tags != null && !tags.isEmpty() ? tags.get(0) : "", true)
-                        + name;
+                        + role.getSuffix();
                 String operationId = CaseUtils.snakeToCamel(operationEntry.getValue().getOperationId());
                 if (operationId == null) {
                     operationId = CaseUtils.pathToCamel(stringPathItemEntry.getKey())
                             + CaseUtils.snakeToCamel(operationEntry.getKey().name().toLowerCase(), true);
                 }
-                buildMethod(openAPI, builder(typeName), stringPathItemEntry,
-                        operationEntry, operationId, responseParameter);
+                buildMethod(openAPI, builder(typeName, role), stringPathItemEntry,
+                        operationEntry, operationId, role, responseParameter);
             }
         }
     }
@@ -87,6 +83,7 @@ public abstract class APIExtractor<T, B> implements TypeSpecExtractor<T> {
                               Map.Entry<String, PathItem> stringPathItemEntry,
                               Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
                               String operationId,
+                              Role role,
                               boolean generateResponseParameter);
 
     static Optional<Content> getSuccessfulReply(Operation operation) {

--- a/src/main/java/ru/curs/hurdygurdy/APIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/APIExtractor.java
@@ -42,6 +42,10 @@ public abstract class APIExtractor<T, B> implements TypeSpecExtractor<T> {
         return builders.computeIfAbsent(className, k -> builderSupplier.apply(className));
     }
 
+    protected Framework getFramework() {
+        return params.getFramework();
+    }
+
     public final void extractTypeSpecs(OpenAPI openAPI, BiConsumer<ClassCategory, T> typeSpecBiConsumer) {
         Paths paths = openAPI.getPaths();
         if (paths == null) return;

--- a/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
+++ b/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
@@ -24,8 +24,8 @@ public class CodegenMojo extends AbstractMojo {
     @Parameter(property = "framework", defaultValue = "spring")
     String framework;
 
-    @Parameter(property = "role", defaultValue = "server")
-    String role;
+    @Parameter(property = "generate", defaultValue = "controller")
+    String generate;
 
     @Parameter(property = "spec", required = true)
     String spec;
@@ -36,6 +36,10 @@ public class CodegenMojo extends AbstractMojo {
     @Parameter(property = "generateResponseParameter", required = false)
     boolean generateResponseParameter = false;
 
+    /**
+     * @deprecated superseded by adding {@code api} to the {@code generate} parameter
+     */
+    @Deprecated
     @Parameter(property = "generateApiInterface", required = false)
     boolean generateApiInterface = false;
 
@@ -50,10 +54,13 @@ public class CodegenMojo extends AbstractMojo {
         GeneratorParams params =
                 GeneratorParams.rootPackage(rootPackage)
                         .generateResponseParameter(generateResponseParameter)
-                        .generateApiInterface(generateApiInterface)
                         .forceSnakeCaseForProperties(forceSnakeCaseForProperties)
                         .framework(Framework.of(framework))
-                        .role(Role.of(role));
+                        .generate(Role.parse(generate));
+        if (generateApiInterface) {
+            getLog().warn("generateApiInterface is deprecated; use <generate>controller,api</generate> instead");
+            params.generateApiInterface(true);
+        }
         Codegen<?> codegen =
                 "java".equalsIgnoreCase(language)
                         ? new JavaCodegen(params)

--- a/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
+++ b/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
@@ -2,7 +2,6 @@ package ru.curs.hurdygurdy;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -12,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 
 @Mojo(
         name = "gen-server",
@@ -46,21 +46,22 @@ public class CodegenMojo extends AbstractMojo {
     @Parameter(property = "forceSnakeCaseForProperties", required = false)
     boolean forceSnakeCaseForProperties = true;
 
-    @Component
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
     MavenProject project;
 
     @Override
     public void execute() throws MojoExecutionException {
+        Set<Role> roles = Role.parse(generate);
+        if (generateApiInterface) {
+            getLog().warn("generateApiInterface is deprecated; use <generate>controller,api</generate> instead");
+            roles.add(Role.API);
+        }
         GeneratorParams params =
                 GeneratorParams.rootPackage(rootPackage)
                         .generateResponseParameter(generateResponseParameter)
                         .forceSnakeCaseForProperties(forceSnakeCaseForProperties)
                         .framework(Framework.of(framework))
-                        .generate(Role.parse(generate));
-        if (generateApiInterface) {
-            getLog().warn("generateApiInterface is deprecated; use <generate>controller,api</generate> instead");
-            params.generateApiInterface(true);
-        }
+                        .generate(roles);
         Codegen<?> codegen =
                 "java".equalsIgnoreCase(language)
                         ? new JavaCodegen(params)

--- a/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
+++ b/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
@@ -21,6 +21,9 @@ public class CodegenMojo extends AbstractMojo {
     @Parameter(property = "language", defaultValue = "java")
     String language;
 
+    @Parameter(property = "framework", defaultValue = "spring")
+    String framework;
+
     @Parameter(property = "spec", required = true)
     String spec;
 
@@ -45,7 +48,8 @@ public class CodegenMojo extends AbstractMojo {
                 GeneratorParams.rootPackage(rootPackage)
                         .generateResponseParameter(generateResponseParameter)
                         .generateApiInterface(generateApiInterface)
-                        .forceSnakeCaseForProperties(forceSnakeCaseForProperties);
+                        .forceSnakeCaseForProperties(forceSnakeCaseForProperties)
+                        .framework(Framework.of(framework));
         Codegen<?> codegen =
                 "java".equalsIgnoreCase(language)
                         ? new JavaCodegen(params)

--- a/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
+++ b/src/main/java/ru/curs/hurdygurdy/CodegenMojo.java
@@ -24,6 +24,9 @@ public class CodegenMojo extends AbstractMojo {
     @Parameter(property = "framework", defaultValue = "spring")
     String framework;
 
+    @Parameter(property = "role", defaultValue = "server")
+    String role;
+
     @Parameter(property = "spec", required = true)
     String spec;
 
@@ -49,7 +52,8 @@ public class CodegenMojo extends AbstractMojo {
                         .generateResponseParameter(generateResponseParameter)
                         .generateApiInterface(generateApiInterface)
                         .forceSnakeCaseForProperties(forceSnakeCaseForProperties)
-                        .framework(Framework.of(framework));
+                        .framework(Framework.of(framework))
+                        .role(Role.of(role));
         Codegen<?> codegen =
                 "java".equalsIgnoreCase(language)
                         ? new JavaCodegen(params)

--- a/src/main/java/ru/curs/hurdygurdy/Framework.java
+++ b/src/main/java/ru/curs/hurdygurdy/Framework.java
@@ -1,0 +1,26 @@
+package ru.curs.hurdygurdy;
+
+/**
+ * Target web framework whose annotations the generator emits on controller
+ * interfaces.
+ */
+public enum Framework {
+    /** Spring Web framework. */
+    SPRING,
+    /** Quarkus Web framework. */
+    QUARKUS;
+
+    /**
+     * Parses a framework name case-insensitively, defaulting to {@link #SPRING}
+     * for a {@code null} or blank value.
+     *
+     * @param value framework name (e.g. {@code "spring"} or {@code "quarkus"})
+     * @return the matching framework, or {@link #SPRING} when unspecified
+     */
+    public static Framework of(String value) {
+        if (value == null || value.isBlank()) {
+            return SPRING;
+        }
+        return Framework.valueOf(value.trim().toUpperCase(java.util.Locale.ROOT));
+    }
+}

--- a/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
+++ b/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
@@ -6,6 +6,7 @@ public final class GeneratorParams {
     private boolean generateApiInterface = false;
     private boolean forceSnakeCaseForProperties = true;
     private Framework framework = Framework.SPRING;
+    private Role role = Role.SERVER;
 
     private GeneratorParams(String rootPackage) {
         this.rootPackage = rootPackage;
@@ -31,6 +32,11 @@ public final class GeneratorParams {
         return this;
     }
 
+    public GeneratorParams role(Role value) {
+        this.role = value;
+        return this;
+    }
+
     public String getRootPackage() {
         return rootPackage;
     }
@@ -49,6 +55,10 @@ public final class GeneratorParams {
 
     public Framework getFramework() {
         return framework;
+    }
+
+    public Role getRole() {
+        return role;
     }
 
     public static GeneratorParams rootPackage(String rootPackage) {

--- a/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
+++ b/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
@@ -1,12 +1,16 @@
 package ru.curs.hurdygurdy;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
 public final class GeneratorParams {
     private final String rootPackage;
     private boolean generateResponseParameter = false;
-    private boolean generateApiInterface = false;
     private boolean forceSnakeCaseForProperties = true;
     private Framework framework = Framework.SPRING;
-    private Role role = Role.SERVER;
+    private final EnumSet<Role> generate = EnumSet.of(Role.CONTROLLER);
 
     private GeneratorParams(String rootPackage) {
         this.rootPackage = rootPackage;
@@ -17,8 +21,50 @@ public final class GeneratorParams {
         return this;
     }
 
+    /**
+     * Selects which interfaces to generate, replacing the current selection
+     * (default: {@link Role#CONTROLLER} only).
+     *
+     * @param roles the roles to generate; must not be empty
+     * @return this
+     */
+    public GeneratorParams generate(Role... roles) {
+        return generate(List.of(roles));
+    }
+
+    /**
+     * Selects which interfaces to generate, replacing the current selection
+     * (default: {@link Role#CONTROLLER} only).
+     *
+     * @param roles the roles to generate; must not be empty
+     * @return this
+     */
+    public GeneratorParams generate(Iterable<Role> roles) {
+        EnumSet<Role> newSet = EnumSet.noneOf(Role.class);
+        roles.forEach(newSet::add);
+        if (newSet.isEmpty()) {
+            throw new IllegalArgumentException("At least one role must be generated");
+        }
+        this.generate.clear();
+        this.generate.addAll(newSet);
+        return this;
+    }
+
+    /**
+     * Adds {@link Role#API} to (or removes it from) the set of generated
+     * interfaces.
+     *
+     * @param value whether to generate the {@code Api} interface
+     * @return this
+     * @deprecated use {@link #generate(Role...)} with {@link Role#API} instead
+     */
+    @Deprecated
     public GeneratorParams generateApiInterface(boolean value) {
-        this.generateApiInterface = value;
+        if (value) {
+            this.generate.add(Role.API);
+        } else {
+            this.generate.remove(Role.API);
+        }
         return this;
     }
 
@@ -32,11 +78,6 @@ public final class GeneratorParams {
         return this;
     }
 
-    public GeneratorParams role(Role value) {
-        this.role = value;
-        return this;
-    }
-
     public String getRootPackage() {
         return rootPackage;
     }
@@ -45,8 +86,17 @@ public final class GeneratorParams {
         return generateResponseParameter;
     }
 
+    public Set<Role> getGenerate() {
+        return Collections.unmodifiableSet(generate);
+    }
+
+    /**
+     * @return whether the {@code Api} interface is generated
+     * @deprecated use {@link #getGenerate()} instead
+     */
+    @Deprecated
     public boolean isGenerateApiInterface() {
-        return generateApiInterface;
+        return generate.contains(Role.API);
     }
 
     public boolean isForceSnakeCaseForProperties() {
@@ -55,10 +105,6 @@ public final class GeneratorParams {
 
     public Framework getFramework() {
         return framework;
-    }
-
-    public Role getRole() {
-        return role;
     }
 
     public static GeneratorParams rootPackage(String rootPackage) {

--- a/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
+++ b/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
@@ -90,15 +90,6 @@ public final class GeneratorParams {
         return Collections.unmodifiableSet(generate);
     }
 
-    /**
-     * @return whether the {@code Api} interface is generated
-     * @deprecated use {@link #getGenerate()} instead
-     */
-    @Deprecated
-    public boolean isGenerateApiInterface() {
-        return generate.contains(Role.API);
-    }
-
     public boolean isForceSnakeCaseForProperties() {
         return forceSnakeCaseForProperties;
     }

--- a/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
+++ b/src/main/java/ru/curs/hurdygurdy/GeneratorParams.java
@@ -5,6 +5,7 @@ public final class GeneratorParams {
     private boolean generateResponseParameter = false;
     private boolean generateApiInterface = false;
     private boolean forceSnakeCaseForProperties = true;
+    private Framework framework = Framework.SPRING;
 
     private GeneratorParams(String rootPackage) {
         this.rootPackage = rootPackage;
@@ -25,6 +26,11 @@ public final class GeneratorParams {
         return this;
     }
 
+    public GeneratorParams framework(Framework value) {
+        this.framework = value;
+        return this;
+    }
+
     public String getRootPackage() {
         return rootPackage;
     }
@@ -39,6 +45,10 @@ public final class GeneratorParams {
 
     public boolean isForceSnakeCaseForProperties() {
         return forceSnakeCaseForProperties;
+    }
+
+    public Framework getFramework() {
+        return framework;
     }
 
     public static GeneratorParams rootPackage(String rootPackage) {

--- a/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
@@ -75,12 +75,12 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
     public JavaAPIExtractor(TypeDefiner<TypeSpec> typeDefiner,
                             GeneratorParams params) {
         super(typeDefiner, params,
-                name -> {
+                (name, role) -> {
                     TypeSpec.Builder b = TypeSpec.interfaceBuilder(normalizeToCamel(name));
                     if (params.getFramework() == Framework.QUARKUS) {
                         b.addAnnotation(AnnotationSpec.builder(JAXRS_PATH)
                                 .addMember("value", "$S", "").build());
-                        if (params.getRole() == Role.CLIENT) {
+                        if (role == Role.CLIENT) {
                             b.addAnnotation(AnnotationSpec.builder(MP_REGISTER_REST_CLIENT).build());
                         }
                     }
@@ -97,11 +97,12 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                      Map.Entry<String, PathItem> stringPathItemEntry,
                      Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
                      String operationId,
+                     Role role,
                      boolean generateResponseParameter) {
         if (getFramework() == Framework.QUARKUS) {
             buildQuarkusMethod(openAPI, classBuilder, stringPathItemEntry,
-                    operationEntry, operationId, generateResponseParameter);
-        } else if (getRole() == Role.CLIENT) {
+                    operationEntry, operationId, role, generateResponseParameter);
+        } else if (role == Role.CLIENT) {
             buildSpringClientMethod(openAPI, classBuilder, stringPathItemEntry,
                     operationEntry, operationId, generateResponseParameter);
         } else {
@@ -192,6 +193,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                      Map.Entry<String, PathItem> stringPathItemEntry,
                      Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
                      String operationId,
+                     Role role,
                      boolean generateResponseParameter) {
         MethodSpec.Builder methodBuilder = MethodSpec
                 .methodBuilder(operationId)
@@ -255,7 +257,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                                 .addMember("value", "$S", parameter.getName()).build())
                         .build()));
         if (generateResponseParameter && isIncludeRequest(operationEntry.getValue())
-                && getRole() == Role.SERVER) {
+                && role == Role.CONTROLLER) {
             methodBuilder.addParameter(ParameterSpec.builder(
                             JAXRS_REQUEST_CONTEXT, "requestContext")
                     .addAnnotation(JAXRS_CONTEXT).build());
@@ -330,27 +332,14 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
 
     private AnnotationSpec getSpringExchangeAnnotationSpec(
             Map.Entry<PathItem.HttpMethod, Operation> operationEntry, String path) {
-        ClassName annotationClass;
-        switch (operationEntry.getKey()) {
-            case GET:
-                annotationClass = SPRING_GET_EXCHANGE;
-                break;
-            case POST:
-                annotationClass = SPRING_POST_EXCHANGE;
-                break;
-            case PUT:
-                annotationClass = SPRING_PUT_EXCHANGE;
-                break;
-            case PATCH:
-                annotationClass = SPRING_PATCH_EXCHANGE;
-                break;
-            case DELETE:
-                annotationClass = SPRING_DELETE_EXCHANGE;
-                break;
-            default:
-                annotationClass = null;
-                break;
-        }
+        ClassName annotationClass = switch (operationEntry.getKey()) {
+            case GET -> SPRING_GET_EXCHANGE;
+            case POST -> SPRING_POST_EXCHANGE;
+            case PUT -> SPRING_PUT_EXCHANGE;
+            case PATCH -> SPRING_PATCH_EXCHANGE;
+            case DELETE -> SPRING_DELETE_EXCHANGE;
+            default -> null;
+        };
         if (annotationClass == null) {
             return null;
         }
@@ -451,27 +440,14 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
     private List<AnnotationSpec> getQuarkusMethodAnnotations(
             Map.Entry<PathItem.HttpMethod, Operation> operationEntry, String path) {
         List<AnnotationSpec> result = new ArrayList<>();
-        ClassName verb;
-        switch (operationEntry.getKey()) {
-            case GET:
-                verb = JAXRS_GET;
-                break;
-            case POST:
-                verb = JAXRS_POST;
-                break;
-            case PUT:
-                verb = JAXRS_PUT;
-                break;
-            case PATCH:
-                verb = JAXRS_PATCH;
-                break;
-            case DELETE:
-                verb = JAXRS_DELETE;
-                break;
-            default:
-                verb = null;
-                break;
-        }
+        ClassName verb = switch (operationEntry.getKey()) {
+            case GET -> JAXRS_GET;
+            case POST -> JAXRS_POST;
+            case PUT -> JAXRS_PUT;
+            case PATCH -> JAXRS_PATCH;
+            case DELETE -> JAXRS_DELETE;
+            default -> null;
+        };
         if (verb == null) {
             return result;
         }
@@ -494,24 +470,14 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
 
     private AnnotationSpec getControllerMethodAnnotationSpec(Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
                                                              String path) {
-        Class<?> annotationClass = null;
-        switch (operationEntry.getKey()) {
-            case GET:
-                annotationClass = GetMapping.class;
-                break;
-            case POST:
-                annotationClass = PostMapping.class;
-                break;
-            case PUT:
-                annotationClass = PutMapping.class;
-                break;
-            case PATCH:
-                annotationClass = PatchMapping.class;
-                break;
-            case DELETE:
-                annotationClass = DeleteMapping.class;
-                break;
-        }
+        Class<?> annotationClass = switch (operationEntry.getKey()) {
+            case GET -> GetMapping.class;
+            case POST -> PostMapping.class;
+            case PUT -> PutMapping.class;
+            case PATCH -> PatchMapping.class;
+            case DELETE -> DeleteMapping.class;
+            default -> null;
+        };
         if (annotationClass != null) {
             AnnotationSpec.Builder builder = AnnotationSpec.builder(annotationClass)
                     .addMember("value", "$S", path);

--- a/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
@@ -4,6 +4,7 @@ import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -56,6 +57,20 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
             ClassName.get("jakarta.ws.rs.container", "ContainerRequestContext");
     private static final ClassName QUARKUS_REST_FORM =
             ClassName.get("org.jboss.resteasy.reactive", "RestForm");
+    private static final ClassName MP_REGISTER_REST_CLIENT =
+            ClassName.get("org.eclipse.microprofile.rest.client.inject", "RegisterRestClient");
+    private static final ClassName SPRING_GET_EXCHANGE =
+            ClassName.get("org.springframework.web.service.annotation", "GetExchange");
+    private static final ClassName SPRING_POST_EXCHANGE =
+            ClassName.get("org.springframework.web.service.annotation", "PostExchange");
+    private static final ClassName SPRING_PUT_EXCHANGE =
+            ClassName.get("org.springframework.web.service.annotation", "PutExchange");
+    private static final ClassName SPRING_PATCH_EXCHANGE =
+            ClassName.get("org.springframework.web.service.annotation", "PatchExchange");
+    private static final ClassName SPRING_DELETE_EXCHANGE =
+            ClassName.get("org.springframework.web.service.annotation", "DeleteExchange");
+    private static final ClassName SPRING_RESPONSE_ENTITY =
+            ClassName.get("org.springframework.http", "ResponseEntity");
 
     public JavaAPIExtractor(TypeDefiner<TypeSpec> typeDefiner,
                             GeneratorParams params) {
@@ -65,6 +80,9 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                     if (params.getFramework() == Framework.QUARKUS) {
                         b.addAnnotation(AnnotationSpec.builder(JAXRS_PATH)
                                 .addMember("value", "$S", "").build());
+                        if (params.getRole() == Role.CLIENT) {
+                            b.addAnnotation(AnnotationSpec.builder(MP_REGISTER_REST_CLIENT).build());
+                        }
                     }
                     return b;
                 },
@@ -82,6 +100,9 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                      boolean generateResponseParameter) {
         if (getFramework() == Framework.QUARKUS) {
             buildQuarkusMethod(openAPI, classBuilder, stringPathItemEntry,
+                    operationEntry, operationId, generateResponseParameter);
+        } else if (getRole() == Role.CLIENT) {
+            buildSpringClientMethod(openAPI, classBuilder, stringPathItemEntry,
                     operationEntry, operationId, generateResponseParameter);
         } else {
             buildSpringMethod(openAPI, classBuilder, stringPathItemEntry,
@@ -233,12 +254,119 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                         .addAnnotation(AnnotationSpec.builder(JAXRS_HEADER_PARAM)
                                 .addMember("value", "$S", parameter.getName()).build())
                         .build()));
-        if (generateResponseParameter && isIncludeRequest(operationEntry.getValue())) {
+        if (generateResponseParameter && isIncludeRequest(operationEntry.getValue())
+                && getRole() == Role.SERVER) {
             methodBuilder.addParameter(ParameterSpec.builder(
                             JAXRS_REQUEST_CONTEXT, "requestContext")
                     .addAnnotation(JAXRS_CONTEXT).build());
         }
         classBuilder.addMethod(methodBuilder.build());
+    }
+
+    private void buildSpringClientMethod(OpenAPI openAPI, TypeSpec.Builder classBuilder,
+                     Map.Entry<String, PathItem> stringPathItemEntry,
+                     Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
+                     String operationId,
+                     boolean generateResponseParameter) {
+        MethodSpec.Builder methodBuilder = MethodSpec
+                .methodBuilder(operationId)
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT);
+        AnnotationSpec exchange =
+                getSpringExchangeAnnotationSpec(operationEntry, stringPathItemEntry.getKey());
+        if (exchange != null) {
+            methodBuilder.addAnnotation(exchange);
+        }
+        TypeName dtoReturn = determineReturnJavaType(operationEntry.getValue(), openAPI, classBuilder);
+        if (generateResponseParameter) {
+            TypeName body = dtoReturn.equals(TypeName.VOID) ? ClassName.get(Void.class) : dtoReturn.box();
+            methodBuilder.returns(ParameterizedTypeName.get(SPRING_RESPONSE_ENTITY, body));
+        } else {
+            methodBuilder.returns(dtoReturn);
+        }
+        Optional.ofNullable(operationEntry.getValue().getRequestBody())
+                .map(RequestBody::getContent)
+                .stream()
+                .flatMap(c -> getContentTypes(c, openAPI, classBuilder, false))
+                .forEach(paramSpec ->
+                        methodBuilder.addParameter(ParameterSpec.builder(
+                                        paramSpec.typeName, paramSpec.name)
+                                .addAnnotation(paramSpec.annotation).build()));
+        getParameterStream(stringPathItemEntry.getValue(), operationEntry.getValue())
+                .filter(parameter -> "path".equalsIgnoreCase(parameter.getIn()))
+                .forEach(parameter -> methodBuilder.addParameter(ParameterSpec.builder(
+                                safeUnbox(typeDefiner.defineJavaType(parameter.getSchema(),
+                                        openAPI, classBuilder, null)),
+                                CaseUtils.snakeToCamel(parameter.getName()))
+                        .addAnnotation(AnnotationSpec.builder(PathVariable.class)
+                                .addMember("name", "$S", parameter.getName()).build())
+                        .build()));
+        getParameterStream(stringPathItemEntry.getValue(), operationEntry.getValue())
+                .filter(parameter -> "query".equalsIgnoreCase(parameter.getIn()))
+                .forEach(parameter -> {
+                    AnnotationSpec.Builder builder = AnnotationSpec.builder(RequestParam.class)
+                            .addMember("required", "$L", parameter.getRequired())
+                            .addMember("name", "$S", parameter.getName());
+                    Optional.ofNullable(parameter.getSchema())
+                            .map(Schema::getDefault)
+                            .ifPresent(d -> builder.addMember("defaultValue", "$S", d.toString()));
+                    methodBuilder.addParameter(ParameterSpec.builder(
+                                    safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI,
+                                            classBuilder, null)),
+                                    CaseUtils.snakeToCamel(parameter.getName()))
+                            .addAnnotation(builder.build()).build());
+                });
+        getParameterStream(stringPathItemEntry.getValue(), operationEntry.getValue())
+                .filter(parameter -> "header".equalsIgnoreCase(parameter.getIn()))
+                .forEach(parameter -> methodBuilder.addParameter(ParameterSpec.builder(
+                                safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI,
+                                        classBuilder, null)),
+                                CaseUtils.kebabToCamel(parameter.getName()))
+                        .addAnnotation(AnnotationSpec.builder(RequestHeader.class)
+                                .addMember("required", "$L", parameter.getRequired())
+                                .addMember("name", "$S", parameter.getName()).build())
+                        .build()));
+        classBuilder.addMethod(methodBuilder.build());
+    }
+
+    private AnnotationSpec getSpringExchangeAnnotationSpec(
+            Map.Entry<PathItem.HttpMethod, Operation> operationEntry, String path) {
+        ClassName annotationClass;
+        switch (operationEntry.getKey()) {
+            case GET:
+                annotationClass = SPRING_GET_EXCHANGE;
+                break;
+            case POST:
+                annotationClass = SPRING_POST_EXCHANGE;
+                break;
+            case PUT:
+                annotationClass = SPRING_PUT_EXCHANGE;
+                break;
+            case PATCH:
+                annotationClass = SPRING_PATCH_EXCHANGE;
+                break;
+            case DELETE:
+                annotationClass = SPRING_DELETE_EXCHANGE;
+                break;
+            default:
+                annotationClass = null;
+                break;
+        }
+        if (annotationClass == null) {
+            return null;
+        }
+        AnnotationSpec.Builder builder = AnnotationSpec.builder(annotationClass)
+                .addMember("value", "$S", path);
+        getSuccessfulReply(operationEntry.getValue())
+                .<Map.Entry<String, MediaType>>flatMap(APIExtractor::getMediaType)
+                .map(Map.Entry::getKey)
+                .ifPresent(mt -> builder.addMember("accept", "$S", mt));
+        Optional.ofNullable(operationEntry.getValue().getRequestBody())
+                .map(RequestBody::getContent)
+                .<Map.Entry<String, MediaType>>flatMap(APIExtractor::getMediaType)
+                .map(Map.Entry::getKey)
+                .filter(s -> !s.isBlank() && !s.equals("application/json"))
+                .ifPresent(mt -> builder.addMember("contentType", "$S", mt));
+        return builder.build();
     }
 
     private static boolean isIncludeRequest(Operation operation) {

--- a/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
@@ -1,6 +1,7 @@
 package ru.curs.hurdygurdy;
 
 import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
@@ -27,6 +28,8 @@ import javax.lang.model.element.Modifier;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -35,19 +38,58 @@ import static ru.curs.hurdygurdy.CaseUtils.normalizeToCamel;
 
 public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
 
+    private static final ClassName JAXRS_PATH = ClassName.get("jakarta.ws.rs", "Path");
+    private static final ClassName JAXRS_GET = ClassName.get("jakarta.ws.rs", "GET");
+    private static final ClassName JAXRS_POST = ClassName.get("jakarta.ws.rs", "POST");
+    private static final ClassName JAXRS_PUT = ClassName.get("jakarta.ws.rs", "PUT");
+    private static final ClassName JAXRS_PATCH = ClassName.get("jakarta.ws.rs", "PATCH");
+    private static final ClassName JAXRS_DELETE = ClassName.get("jakarta.ws.rs", "DELETE");
+    private static final ClassName JAXRS_PRODUCES = ClassName.get("jakarta.ws.rs", "Produces");
+    private static final ClassName JAXRS_CONSUMES = ClassName.get("jakarta.ws.rs", "Consumes");
+    private static final ClassName JAXRS_PATH_PARAM = ClassName.get("jakarta.ws.rs", "PathParam");
+    private static final ClassName JAXRS_QUERY_PARAM = ClassName.get("jakarta.ws.rs", "QueryParam");
+    private static final ClassName JAXRS_DEFAULT_VALUE = ClassName.get("jakarta.ws.rs", "DefaultValue");
+    private static final ClassName JAXRS_HEADER_PARAM = ClassName.get("jakarta.ws.rs", "HeaderParam");
+    private static final ClassName JAXRS_CONTEXT = ClassName.get("jakarta.ws.rs.core", "Context");
+    private static final ClassName JAXRS_RESPONSE = ClassName.get("jakarta.ws.rs.core", "Response");
+    private static final ClassName JAXRS_REQUEST_CONTEXT =
+            ClassName.get("jakarta.ws.rs.container", "ContainerRequestContext");
+    private static final ClassName QUARKUS_REST_FORM =
+            ClassName.get("org.jboss.resteasy.reactive", "RestForm");
+
     public JavaAPIExtractor(TypeDefiner<TypeSpec> typeDefiner,
                             GeneratorParams params) {
         super(typeDefiner, params,
-                name -> TypeSpec.interfaceBuilder(normalizeToCamel(name)),
+                name -> {
+                    TypeSpec.Builder b = TypeSpec.interfaceBuilder(normalizeToCamel(name));
+                    if (params.getFramework() == Framework.QUARKUS) {
+                        b.addAnnotation(AnnotationSpec.builder(JAXRS_PATH)
+                                .addMember("value", "$S", "").build());
+                    }
+                    return b;
+                },
                 b -> {
                     b.addModifiers(Modifier.PUBLIC);
                     return b.build();
                 });
     }
 
-
     @Override
     void buildMethod(OpenAPI openAPI, TypeSpec.Builder classBuilder,
+                     Map.Entry<String, PathItem> stringPathItemEntry,
+                     Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
+                     String operationId,
+                     boolean generateResponseParameter) {
+        if (getFramework() == Framework.QUARKUS) {
+            buildQuarkusMethod(openAPI, classBuilder, stringPathItemEntry,
+                    operationEntry, operationId, generateResponseParameter);
+        } else {
+            buildSpringMethod(openAPI, classBuilder, stringPathItemEntry,
+                    operationEntry, operationId, generateResponseParameter);
+        }
+    }
+
+    private void buildSpringMethod(OpenAPI openAPI, TypeSpec.Builder classBuilder,
                      Map.Entry<String, PathItem> stringPathItemEntry,
                      Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
                      String operationId,
@@ -61,7 +103,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
         Optional.ofNullable(operationEntry.getValue().getRequestBody())
                 .map(RequestBody::getContent)
                 .stream()
-                .flatMap(c -> getContentTypes(c, openAPI, classBuilder))
+                .flatMap(c -> getContentTypes(c, openAPI, classBuilder, false))
                 .forEach(paramSpec ->
                         methodBuilder.addParameter(ParameterSpec.builder(
                                         paramSpec.typeName,
@@ -113,14 +155,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                                         .addMember("name", "$S", parameter.getName()).build()
                         ).build()));
         if (generateResponseParameter) {
-            boolean includeRequest = Optional.ofNullable(operationEntry.getValue().getExtensions())
-                    .map(m -> m.get("x-include-request"))
-                    .map(v -> {
-                        if (v instanceof Boolean) return (Boolean) v;
-                        if (v instanceof String) return Boolean.parseBoolean((String) v);
-                        return false;
-                    }).orElse(false);
-            if (includeRequest) {
+            if (isIncludeRequest(operationEntry.getValue())) {
                 methodBuilder.addParameter(ParameterSpec.builder(
                         HttpServletRequest.class,
                         "request").build());
@@ -130,6 +165,90 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                     "response").build());
         }
         classBuilder.addMethod(methodBuilder.build());
+    }
+
+    private void buildQuarkusMethod(OpenAPI openAPI, TypeSpec.Builder classBuilder,
+                     Map.Entry<String, PathItem> stringPathItemEntry,
+                     Map.Entry<PathItem.HttpMethod, Operation> operationEntry,
+                     String operationId,
+                     boolean generateResponseParameter) {
+        MethodSpec.Builder methodBuilder = MethodSpec
+                .methodBuilder(operationId)
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT);
+        getQuarkusMethodAnnotations(operationEntry, stringPathItemEntry.getKey())
+                .forEach(methodBuilder::addAnnotation);
+
+        TypeName dtoReturn = determineReturnJavaType(operationEntry.getValue(), openAPI, classBuilder);
+        if (generateResponseParameter) {
+            methodBuilder.returns(JAXRS_RESPONSE);
+            methodBuilder.addJavadoc("@return a $T whose entity is expected to be $L\n",
+                    JAXRS_RESPONSE,
+                    dtoReturn.equals(TypeName.VOID) ? "empty (no body)" : dtoReturn.toString());
+        } else {
+            methodBuilder.returns(dtoReturn);
+        }
+
+        Optional.ofNullable(operationEntry.getValue().getRequestBody())
+                .map(RequestBody::getContent)
+                .stream()
+                .flatMap(c -> getContentTypes(c, openAPI, classBuilder, true))
+                .forEach(paramSpec -> {
+                    ParameterSpec.Builder pb = ParameterSpec.builder(
+                            paramSpec.typeName, CaseUtils.toIdentifier(paramSpec.name));
+                    if (paramSpec.annotation != null) {
+                        pb.addAnnotation(paramSpec.annotation);
+                    }
+                    methodBuilder.addParameter(pb.build());
+                });
+
+        getParameterStream(stringPathItemEntry.getValue(), operationEntry.getValue())
+                .filter(parameter -> "path".equalsIgnoreCase(parameter.getIn()))
+                .forEach(parameter -> methodBuilder.addParameter(ParameterSpec.builder(
+                                safeUnbox(typeDefiner.defineJavaType(parameter.getSchema(),
+                                        openAPI, classBuilder, null)),
+                                CaseUtils.toIdentifier(CaseUtils.snakeToCamel(parameter.getName())))
+                        .addAnnotation(AnnotationSpec.builder(JAXRS_PATH_PARAM)
+                                .addMember("value", "$S", parameter.getName()).build())
+                        .build()));
+        getParameterStream(stringPathItemEntry.getValue(), operationEntry.getValue())
+                .filter(parameter -> "query".equalsIgnoreCase(parameter.getIn()))
+                .forEach(parameter -> {
+                    ParameterSpec.Builder pb = ParameterSpec.builder(
+                                    safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI,
+                                            classBuilder, null)),
+                                    CaseUtils.toIdentifier(CaseUtils.snakeToCamel(parameter.getName())))
+                            .addAnnotation(AnnotationSpec.builder(JAXRS_QUERY_PARAM)
+                                    .addMember("value", "$S", parameter.getName()).build());
+                    Optional.ofNullable(parameter.getSchema())
+                            .map(Schema::getDefault)
+                            .ifPresent(d -> pb.addAnnotation(AnnotationSpec.builder(JAXRS_DEFAULT_VALUE)
+                                    .addMember("value", "$S", d.toString()).build()));
+                    methodBuilder.addParameter(pb.build());
+                });
+        getParameterStream(stringPathItemEntry.getValue(), operationEntry.getValue())
+                .filter(parameter -> "header".equalsIgnoreCase(parameter.getIn()))
+                .forEach(parameter -> methodBuilder.addParameter(ParameterSpec.builder(
+                                safeBox(typeDefiner.defineJavaType(parameter.getSchema(), openAPI, classBuilder, null)),
+                                CaseUtils.toIdentifier(CaseUtils.kebabToCamel(parameter.getName())))
+                        .addAnnotation(AnnotationSpec.builder(JAXRS_HEADER_PARAM)
+                                .addMember("value", "$S", parameter.getName()).build())
+                        .build()));
+        if (generateResponseParameter && isIncludeRequest(operationEntry.getValue())) {
+            methodBuilder.addParameter(ParameterSpec.builder(
+                            JAXRS_REQUEST_CONTEXT, "requestContext")
+                    .addAnnotation(JAXRS_CONTEXT).build());
+        }
+        classBuilder.addMethod(methodBuilder.build());
+    }
+
+    private static boolean isIncludeRequest(Operation operation) {
+        return Optional.ofNullable(operation.getExtensions())
+                .map(m -> m.get("x-include-request"))
+                .map(v -> {
+                    if (v instanceof Boolean) return (Boolean) v;
+                    if (v instanceof String) return Boolean.parseBoolean((String) v);
+                    return false;
+                }).orElse(false);
     }
 
     private static TypeName safeBox(TypeName name) {
@@ -143,7 +262,7 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
     private TypeName determineReturnJavaType(Operation operation, OpenAPI openAPI, TypeSpec.Builder parent) {
         return getSuccessfulReply(operation)
                 .stream()
-                .flatMap(c -> getContentTypes(c, openAPI, parent))
+                .flatMap(c -> getContentTypes(c, openAPI, parent, false))
                 .map(p -> p.typeName)
                 .findFirst()
                 .orElse(TypeName.VOID);
@@ -161,7 +280,8 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
         }
     }
 
-    private Stream<RequestPartParams> getContentTypes(Content content, OpenAPI openAPI, TypeSpec.Builder parent) {
+    private Stream<RequestPartParams> getContentTypes(Content content, OpenAPI openAPI,
+                                                      TypeSpec.Builder parent, boolean quarkus) {
         final Optional<Map.Entry<String, MediaType>> mediaTypeEntry =
                 Optional.ofNullable(content)
                         .<Map.Entry<String, MediaType>>flatMap(APIExtractor::getMediaType);
@@ -179,8 +299,11 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                                 JavaAPIExtractor.safeUnbox(typeDefiner.defineJavaType(e.getValue(), openAPI,
                                         parent, null)),
                                 e.getKey(),
-                                AnnotationSpec.builder(RequestPart.class)
-                                        .addMember("name", "$S", e.getKey()).build()));
+                                quarkus
+                                        ? AnnotationSpec.builder(QUARKUS_REST_FORM)
+                                                .addMember("value", "$S", e.getKey()).build()
+                                        : AnnotationSpec.builder(RequestPart.class)
+                                                .addMember("name", "$S", e.getKey()).build()));
             } else {
                 //Single-part
                 return Optional.ofNullable(entry.getValue().getSchema()).stream()
@@ -188,10 +311,57 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                         .map(JavaAPIExtractor::safeUnbox).map(t ->
                                 new RequestPartParams(t,
                                         "request",
-                                        AnnotationSpec.builder(
-                                                org.springframework.web.bind.annotation.RequestBody.class).build()));
+                                        quarkus
+                                                ? null
+                                                : AnnotationSpec.builder(
+                                                        org.springframework.web.bind.annotation.RequestBody.class)
+                                                        .build()));
             }
         }
+    }
+
+    private List<AnnotationSpec> getQuarkusMethodAnnotations(
+            Map.Entry<PathItem.HttpMethod, Operation> operationEntry, String path) {
+        List<AnnotationSpec> result = new ArrayList<>();
+        ClassName verb;
+        switch (operationEntry.getKey()) {
+            case GET:
+                verb = JAXRS_GET;
+                break;
+            case POST:
+                verb = JAXRS_POST;
+                break;
+            case PUT:
+                verb = JAXRS_PUT;
+                break;
+            case PATCH:
+                verb = JAXRS_PATCH;
+                break;
+            case DELETE:
+                verb = JAXRS_DELETE;
+                break;
+            default:
+                verb = null;
+                break;
+        }
+        if (verb == null) {
+            return result;
+        }
+        result.add(AnnotationSpec.builder(verb).build());
+        result.add(AnnotationSpec.builder(JAXRS_PATH).addMember("value", "$S", path).build());
+        getSuccessfulReply(operationEntry.getValue())
+                .<Map.Entry<String, MediaType>>flatMap(APIExtractor::getMediaType)
+                .map(Map.Entry::getKey)
+                .ifPresent(mt -> result.add(AnnotationSpec.builder(JAXRS_PRODUCES)
+                        .addMember("value", "$S", mt).build()));
+        Optional.ofNullable(operationEntry.getValue().getRequestBody())
+                .map(RequestBody::getContent)
+                .<Map.Entry<String, MediaType>>flatMap(APIExtractor::getMediaType)
+                .map(Map.Entry::getKey)
+                .filter(s -> !s.isBlank())
+                .ifPresent(mt -> result.add(AnnotationSpec.builder(JAXRS_CONSUMES)
+                        .addMember("value", "$S", mt).build()));
+        return result;
     }
 
     private AnnotationSpec getControllerMethodAnnotationSpec(Map.Entry<PathItem.HttpMethod, Operation> operationEntry,

--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -93,7 +93,9 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
                     } else if ("uuid".equals(schema.getFormat())) {
                         return ClassName.get(UUID.class);
                     } else if ("binary".equals(schema.getFormat())) {
-                        return ClassName.get(MultipartFile.class);
+                        return params.getFramework() == Framework.QUARKUS
+                                ? ClassName.get("org.jboss.resteasy.reactive.multipart", "FileUpload")
+                                : ClassName.get(MultipartFile.class);
                     } else if (schema.getEnum() != null) {
                         //internal enum
                         String simpleName = getEnumName(schema, typeNameFallback);

--- a/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
@@ -1,6 +1,7 @@
 package ru.curs.hurdygurdy
 
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
@@ -28,11 +29,60 @@ class KotlinAPIExtractor(
     APIExtractor<TypeSpec, TypeSpec.Builder>(
         typeDefiner,
         params,
-        { TypeSpec.interfaceBuilder(normalizeToCamel(it)) },
+        {
+            val b = TypeSpec.interfaceBuilder(normalizeToCamel(it))
+            if (params.framework == Framework.QUARKUS) {
+                b.addAnnotation(
+                    AnnotationSpec.builder(ClassName("jakarta.ws.rs", "Path"))
+                        .addMember("%S", "").build()
+                )
+            }
+            b
+        },
         TypeSpec.Builder::build
     ) {
 
+    private companion object {
+        val JAXRS_PATH = ClassName("jakarta.ws.rs", "Path")
+        val JAXRS_GET = ClassName("jakarta.ws.rs", "GET")
+        val JAXRS_POST = ClassName("jakarta.ws.rs", "POST")
+        val JAXRS_PUT = ClassName("jakarta.ws.rs", "PUT")
+        val JAXRS_PATCH = ClassName("jakarta.ws.rs", "PATCH")
+        val JAXRS_DELETE = ClassName("jakarta.ws.rs", "DELETE")
+        val JAXRS_PRODUCES = ClassName("jakarta.ws.rs", "Produces")
+        val JAXRS_CONSUMES = ClassName("jakarta.ws.rs", "Consumes")
+        val JAXRS_PATH_PARAM = ClassName("jakarta.ws.rs", "PathParam")
+        val JAXRS_QUERY_PARAM = ClassName("jakarta.ws.rs", "QueryParam")
+        val JAXRS_DEFAULT_VALUE = ClassName("jakarta.ws.rs", "DefaultValue")
+        val JAXRS_HEADER_PARAM = ClassName("jakarta.ws.rs", "HeaderParam")
+        val JAXRS_CONTEXT = ClassName("jakarta.ws.rs.core", "Context")
+        val JAXRS_RESPONSE = ClassName("jakarta.ws.rs.core", "Response")
+        val JAXRS_REQUEST_CONTEXT = ClassName("jakarta.ws.rs.container", "ContainerRequestContext")
+        val QUARKUS_REST_FORM = ClassName("org.jboss.resteasy.reactive", "RestForm")
+    }
+
     public override fun buildMethod(
+        openAPI: OpenAPI,
+        classBuilder: TypeSpec.Builder,
+        stringPathItemEntry: Map.Entry<String, PathItem>,
+        operationEntry: Map.Entry<PathItem.HttpMethod, Operation>,
+        operationId: String,
+        generateResponseParameter: Boolean
+    ) {
+        if (framework == Framework.QUARKUS) {
+            buildQuarkusMethod(
+                openAPI, classBuilder, stringPathItemEntry,
+                operationEntry, operationId, generateResponseParameter
+            )
+        } else {
+            buildSpringMethod(
+                openAPI, classBuilder, stringPathItemEntry,
+                operationEntry, operationId, generateResponseParameter
+            )
+        }
+    }
+
+    private fun buildSpringMethod(
         openAPI: OpenAPI,
         classBuilder: TypeSpec.Builder,
         stringPathItemEntry: Map.Entry<String, PathItem>,
@@ -49,13 +99,13 @@ class KotlinAPIExtractor(
         Optional.ofNullable(operationEntry.value.requestBody)
             .map { obj: RequestBody -> obj.content }
             .stream().asSequence()
-            .flatMap { getContentType(it, openAPI, classBuilder) }
+            .flatMap { getContentType(it, openAPI, classBuilder, false) }
             .forEach { paramSpec: RequestPartParams ->
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
                         CaseUtils.toIdentifier(paramSpec.name),
                         paramSpec.typeName
-                    ).addAnnotation(paramSpec.annotation).build()
+                    ).addAnnotation(paramSpec.annotation!!).build()
                 )
             }
 
@@ -124,16 +174,7 @@ class KotlinAPIExtractor(
                 )
             }
         if (generateResponseParameter) {
-            val includeRequest = Optional.ofNullable(operationEntry.value.extensions)
-                .map { it["x-include-request"] }
-                .map {
-                    when (it) {
-                        is Boolean -> it
-                        is String -> it.toBoolean()
-                        else -> false
-                    }
-                }.orElse(false)
-            if (includeRequest) {
+            if (isIncludeRequest(operationEntry.value)) {
                 methodBuilder.addParameter(
                     ParameterSpec.builder(
                         "request",
@@ -149,6 +190,143 @@ class KotlinAPIExtractor(
             )
         }
         classBuilder.addFunction(methodBuilder.build())
+    }
+
+    private fun buildQuarkusMethod(
+        openAPI: OpenAPI,
+        classBuilder: TypeSpec.Builder,
+        stringPathItemEntry: Map.Entry<String, PathItem>,
+        operationEntry: Map.Entry<PathItem.HttpMethod, Operation>,
+        operationId: String,
+        generateResponseParameter: Boolean
+    ) {
+        val methodBuilder = FunSpec
+            .builder(operationId)
+            .addModifiers(KModifier.PUBLIC, KModifier.ABSTRACT)
+        getQuarkusMethodAnnotations(operationEntry, stringPathItemEntry.key)
+            .forEach(methodBuilder::addAnnotation)
+
+        val dtoReturn = determineReturnKotlinType(operationEntry.value, openAPI, classBuilder)
+        if (generateResponseParameter) {
+            methodBuilder.returns(JAXRS_RESPONSE)
+            methodBuilder.addKdoc(
+                "@return a Response whose entity is expected to be %L\n",
+                if (dtoReturn == UNIT) "empty (no body)" else dtoReturn.toString()
+            )
+        } else {
+            methodBuilder.returns(dtoReturn)
+        }
+
+        Optional.ofNullable(operationEntry.value.requestBody)
+            .map { obj: RequestBody -> obj.content }
+            .stream().asSequence()
+            .flatMap { getContentType(it, openAPI, classBuilder, true) }
+            .forEach { paramSpec: RequestPartParams ->
+                val pb = ParameterSpec.builder(paramSpec.name, paramSpec.typeName)
+                paramSpec.annotation?.let(pb::addAnnotation)
+                methodBuilder.addParameter(pb.build())
+            }
+
+        getParameterStream(stringPathItemEntry.value, operationEntry.value)
+            .filter { parameter: Parameter -> "path".equals(parameter.getIn(), ignoreCase = true) }
+            .forEach { parameter: Parameter ->
+                methodBuilder.addParameter(
+                    ParameterSpec.builder(
+                        CaseUtils.snakeToCamel(parameter.name),
+                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
+                    )
+                        .addAnnotation(
+                            AnnotationSpec.builder(JAXRS_PATH_PARAM)
+                                .addMember("%S", parameter.name).build()
+                        )
+                        .build()
+                )
+            }
+        getParameterStream(stringPathItemEntry.value, operationEntry.value)
+            .filter { parameter: Parameter -> "query".equals(parameter.getIn(), ignoreCase = true) }
+            .forEach { parameter: Parameter ->
+                val pb = ParameterSpec.builder(
+                    CaseUtils.snakeToCamel(parameter.name),
+                    typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
+                )
+                    .addAnnotation(
+                        AnnotationSpec.builder(JAXRS_QUERY_PARAM)
+                            .addMember("%S", parameter.name).build()
+                    )
+                parameter.schema?.default?.let {
+                    pb.addAnnotation(
+                        AnnotationSpec.builder(JAXRS_DEFAULT_VALUE)
+                            .addMember("%S", it.toString()).build()
+                    )
+                }
+                methodBuilder.addParameter(pb.build())
+            }
+        getParameterStream(stringPathItemEntry.value, operationEntry.value)
+            .filter { parameter: Parameter -> "header".equals(parameter.getIn(), ignoreCase = true) }
+            .forEach { parameter: Parameter ->
+                methodBuilder.addParameter(
+                    ParameterSpec.builder(
+                        CaseUtils.kebabToCamel(parameter.name),
+                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
+                    )
+                        .addAnnotation(
+                            AnnotationSpec.builder(JAXRS_HEADER_PARAM)
+                                .addMember("%S", parameter.name).build()
+                        ).build()
+                )
+            }
+        if (generateResponseParameter && isIncludeRequest(operationEntry.value)) {
+            methodBuilder.addParameter(
+                ParameterSpec.builder("requestContext", JAXRS_REQUEST_CONTEXT)
+                    .addAnnotation(JAXRS_CONTEXT)
+                    .build()
+            )
+        }
+        classBuilder.addFunction(methodBuilder.build())
+    }
+
+    private fun isIncludeRequest(operation: Operation): Boolean =
+        Optional.ofNullable(operation.extensions)
+            .map { it["x-include-request"] }
+            .map {
+                when (it) {
+                    is Boolean -> it
+                    is String -> it.toBoolean()
+                    else -> false
+                }
+            }.orElse(false)
+
+    private fun getQuarkusMethodAnnotations(
+        operationEntry: Map.Entry<PathItem.HttpMethod, Operation>,
+        path: String
+    ): List<AnnotationSpec> {
+        val verb: ClassName = when (operationEntry.key) {
+            PathItem.HttpMethod.GET -> JAXRS_GET
+            PathItem.HttpMethod.POST -> JAXRS_POST
+            PathItem.HttpMethod.PUT -> JAXRS_PUT
+            PathItem.HttpMethod.PATCH -> JAXRS_PATCH
+            PathItem.HttpMethod.DELETE -> JAXRS_DELETE
+            else -> return emptyList()
+        }
+        val result = mutableListOf(
+            AnnotationSpec.builder(verb).build(),
+            AnnotationSpec.builder(JAXRS_PATH).addMember("%S", path).build()
+        )
+        getSuccessfulReply(operationEntry.value)
+            .flatMap(::getMediaType)
+            .map { it.key }
+            .ifPresent {
+                result.add(AnnotationSpec.builder(JAXRS_PRODUCES).addMember("%S", it).build())
+            }
+        Optional.ofNullable(operationEntry.value.requestBody)
+            .map { it.content }
+            .flatMap(::getMediaType)
+            .map { it.key }
+            .filter { it.isNotBlank() }
+            .ifPresent {
+                result.add(AnnotationSpec.builder(JAXRS_CONSUMES).addMember("%S", it).build())
+            }
+        return result
     }
 
     private fun getControllerMethodAnnotationSpec(
@@ -184,7 +362,7 @@ class KotlinAPIExtractor(
         getSuccessfulReply(operation)
             .stream().asSequence()
             .flatMap { c: Content ->
-                getContentType(c, openAPI, parent)
+                getContentType(c, openAPI, parent, false)
             }
             .map { it.typeName }
             .firstOrNull() ?: UNIT
@@ -192,13 +370,14 @@ class KotlinAPIExtractor(
     private data class RequestPartParams(
         val typeName: TypeName,
         val name: String,
-        val annotation: AnnotationSpec
+        val annotation: AnnotationSpec?
     )
 
     private fun getContentType(
         content: Content,
         openAPI: OpenAPI,
-        parent: TypeSpec.Builder
+        parent: TypeSpec.Builder,
+        quarkus: Boolean
     ): Sequence<RequestPartParams> {
         val mediaTypeEntry = Optional.ofNullable(content)
             .flatMap { getMediaType(it) }
@@ -213,8 +392,12 @@ class KotlinAPIExtractor(
                         RequestPartParams(
                             name = name,
                             typeName = typeDefiner.defineKotlinType(schema, openAPI, parent, null, null),
-                            annotation = AnnotationSpec.builder(RequestPart::class)
-                                .addMember("name = %S", name).build()
+                            annotation = if (quarkus)
+                                AnnotationSpec.builder(QUARKUS_REST_FORM)
+                                    .addMember("%S", name).build()
+                            else
+                                AnnotationSpec.builder(RequestPart::class)
+                                    .addMember("name = %S", name).build()
                         )
                     }
 
@@ -226,9 +409,12 @@ class KotlinAPIExtractor(
                         RequestPartParams(
                             name = "request",
                             typeName = it,
-                            annotation = AnnotationSpec
-                                .builder(org.springframework.web.bind.annotation.RequestBody::class)
-                                .build()
+                            annotation = if (quarkus)
+                                null
+                            else
+                                AnnotationSpec
+                                    .builder(org.springframework.web.bind.annotation.RequestBody::class)
+                                    .build()
                         )
                     }
             }

--- a/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
@@ -30,14 +30,14 @@ class KotlinAPIExtractor(
     APIExtractor<TypeSpec, TypeSpec.Builder>(
         typeDefiner,
         params,
-        {
-            val b = TypeSpec.interfaceBuilder(normalizeToCamel(it))
+        { name, role ->
+            val b = TypeSpec.interfaceBuilder(normalizeToCamel(name))
             if (params.framework == Framework.QUARKUS) {
                 b.addAnnotation(
                     AnnotationSpec.builder(ClassName("jakarta.ws.rs", "Path"))
                         .addMember("%S", "").build()
                 )
-                if (params.role == Role.CLIENT) {
+                if (role == Role.CLIENT) {
                     b.addAnnotation(AnnotationSpec.builder(MP_REGISTER_REST_CLIENT).build())
                 }
             }
@@ -79,12 +79,13 @@ class KotlinAPIExtractor(
         stringPathItemEntry: Map.Entry<String, PathItem>,
         operationEntry: Map.Entry<PathItem.HttpMethod, Operation>,
         operationId: String,
+        role: Role,
         generateResponseParameter: Boolean
     ) {
         if (framework == Framework.QUARKUS) {
             buildQuarkusMethod(
                 openAPI, classBuilder, stringPathItemEntry,
-                operationEntry, operationId, generateResponseParameter
+                operationEntry, operationId, role, generateResponseParameter
             )
         } else if (role == Role.CLIENT) {
             buildSpringClientMethod(
@@ -215,6 +216,7 @@ class KotlinAPIExtractor(
         stringPathItemEntry: Map.Entry<String, PathItem>,
         operationEntry: Map.Entry<PathItem.HttpMethod, Operation>,
         operationId: String,
+        role: Role,
         generateResponseParameter: Boolean
     ) {
         val methodBuilder = FunSpec
@@ -292,7 +294,7 @@ class KotlinAPIExtractor(
                         ).build()
                 )
             }
-        if (generateResponseParameter && isIncludeRequest(operationEntry.value) && role == Role.SERVER) {
+        if (generateResponseParameter && isIncludeRequest(operationEntry.value) && role == Role.CONTROLLER) {
             methodBuilder.addParameter(
                 ParameterSpec.builder("requestContext", JAXRS_REQUEST_CONTEXT)
                     .addAnnotation(JAXRS_CONTEXT)

--- a/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.UNIT
@@ -36,6 +37,9 @@ class KotlinAPIExtractor(
                     AnnotationSpec.builder(ClassName("jakarta.ws.rs", "Path"))
                         .addMember("%S", "").build()
                 )
+                if (params.role == Role.CLIENT) {
+                    b.addAnnotation(AnnotationSpec.builder(MP_REGISTER_REST_CLIENT).build())
+                }
             }
             b
         },
@@ -59,6 +63,14 @@ class KotlinAPIExtractor(
         val JAXRS_RESPONSE = ClassName("jakarta.ws.rs.core", "Response")
         val JAXRS_REQUEST_CONTEXT = ClassName("jakarta.ws.rs.container", "ContainerRequestContext")
         val QUARKUS_REST_FORM = ClassName("org.jboss.resteasy.reactive", "RestForm")
+        val MP_REGISTER_REST_CLIENT =
+            ClassName("org.eclipse.microprofile.rest.client.inject", "RegisterRestClient")
+        val SPRING_GET_EXCHANGE = ClassName("org.springframework.web.service.annotation", "GetExchange")
+        val SPRING_POST_EXCHANGE = ClassName("org.springframework.web.service.annotation", "PostExchange")
+        val SPRING_PUT_EXCHANGE = ClassName("org.springframework.web.service.annotation", "PutExchange")
+        val SPRING_PATCH_EXCHANGE = ClassName("org.springframework.web.service.annotation", "PatchExchange")
+        val SPRING_DELETE_EXCHANGE = ClassName("org.springframework.web.service.annotation", "DeleteExchange")
+        val SPRING_RESPONSE_ENTITY = ClassName("org.springframework.http", "ResponseEntity")
     }
 
     public override fun buildMethod(
@@ -71,6 +83,11 @@ class KotlinAPIExtractor(
     ) {
         if (framework == Framework.QUARKUS) {
             buildQuarkusMethod(
+                openAPI, classBuilder, stringPathItemEntry,
+                operationEntry, operationId, generateResponseParameter
+            )
+        } else if (role == Role.CLIENT) {
+            buildSpringClientMethod(
                 openAPI, classBuilder, stringPathItemEntry,
                 operationEntry, operationId, generateResponseParameter
             )
@@ -275,7 +292,7 @@ class KotlinAPIExtractor(
                         ).build()
                 )
             }
-        if (generateResponseParameter && isIncludeRequest(operationEntry.value)) {
+        if (generateResponseParameter && isIncludeRequest(operationEntry.value) && role == Role.SERVER) {
             methodBuilder.addParameter(
                 ParameterSpec.builder("requestContext", JAXRS_REQUEST_CONTEXT)
                     .addAnnotation(JAXRS_CONTEXT)
@@ -283,6 +300,105 @@ class KotlinAPIExtractor(
             )
         }
         classBuilder.addFunction(methodBuilder.build())
+    }
+
+    private fun buildSpringClientMethod(
+        openAPI: OpenAPI,
+        classBuilder: TypeSpec.Builder,
+        stringPathItemEntry: Map.Entry<String, PathItem>,
+        operationEntry: Map.Entry<PathItem.HttpMethod, Operation>,
+        operationId: String,
+        generateResponseParameter: Boolean
+    ) {
+        val methodBuilder = FunSpec
+            .builder(operationId)
+            .addModifiers(KModifier.PUBLIC, KModifier.ABSTRACT)
+        getSpringExchangeAnnotationSpec(operationEntry, stringPathItemEntry.key)
+            ?.let(methodBuilder::addAnnotation)
+        val dtoReturn = determineReturnKotlinType(operationEntry.value, openAPI, classBuilder)
+        if (generateResponseParameter) {
+            methodBuilder.returns(SPRING_RESPONSE_ENTITY.parameterizedBy(dtoReturn.copy(nullable = false)))
+        } else {
+            methodBuilder.returns(dtoReturn)
+        }
+        Optional.ofNullable(operationEntry.value.requestBody)
+            .map { obj: RequestBody -> obj.content }
+            .stream().asSequence()
+            .flatMap { getContentType(it, openAPI, classBuilder, false) }
+            .forEach { paramSpec: RequestPartParams ->
+                methodBuilder.addParameter(
+                    ParameterSpec.builder(paramSpec.name, paramSpec.typeName)
+                        .addAnnotation(paramSpec.annotation!!).build()
+                )
+            }
+        getParameterStream(stringPathItemEntry.value, operationEntry.value)
+            .filter { "path".equals(it.getIn(), ignoreCase = true) }
+            .forEach { parameter: Parameter ->
+                methodBuilder.addParameter(
+                    ParameterSpec.builder(
+                        CaseUtils.snakeToCamel(parameter.name),
+                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
+                    ).addAnnotation(
+                        AnnotationSpec.builder(PathVariable::class)
+                            .addMember("name = %S", parameter.name).build()
+                    ).build()
+                )
+            }
+        getParameterStream(stringPathItemEntry.value, operationEntry.value)
+            .filter { "query".equals(it.getIn(), ignoreCase = true) }
+            .forEach { parameter: Parameter ->
+                val builder = AnnotationSpec.builder(RequestParam::class)
+                    .addMember("required = %L", parameter.required)
+                    .addMember("name = %S", parameter.name)
+                parameter.schema?.default?.let { builder.addMember("defaultValue = %S", it.toString()) }
+                methodBuilder.addParameter(
+                    ParameterSpec.builder(
+                        CaseUtils.snakeToCamel(parameter.name),
+                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
+                    ).addAnnotation(builder.build()).build()
+                )
+            }
+        getParameterStream(stringPathItemEntry.value, operationEntry.value)
+            .filter { "header".equals(it.getIn(), ignoreCase = true) }
+            .forEach { parameter: Parameter ->
+                methodBuilder.addParameter(
+                    ParameterSpec.builder(
+                        CaseUtils.kebabToCamel(parameter.name),
+                        typeDefiner.defineKotlinType(parameter.schema, openAPI, classBuilder, null, null),
+                    ).addAnnotation(
+                        AnnotationSpec.builder(RequestHeader::class)
+                            .addMember("required = %L", parameter.required)
+                            .addMember("name = %S", parameter.name).build()
+                    ).build()
+                )
+            }
+        classBuilder.addFunction(methodBuilder.build())
+    }
+
+    private fun getSpringExchangeAnnotationSpec(
+        operationEntry: Map.Entry<PathItem.HttpMethod, Operation>,
+        path: String
+    ): AnnotationSpec? {
+        val annotationClass: ClassName = when (operationEntry.key) {
+            PathItem.HttpMethod.GET -> SPRING_GET_EXCHANGE
+            PathItem.HttpMethod.POST -> SPRING_POST_EXCHANGE
+            PathItem.HttpMethod.PUT -> SPRING_PUT_EXCHANGE
+            PathItem.HttpMethod.PATCH -> SPRING_PATCH_EXCHANGE
+            PathItem.HttpMethod.DELETE -> SPRING_DELETE_EXCHANGE
+            else -> return null
+        }
+        val builder = AnnotationSpec.builder(annotationClass).addMember("value = %S", path)
+        getSuccessfulReply(operationEntry.value)
+            .flatMap(::getMediaType)
+            .map { it.key }
+            .ifPresent { builder.addMember("accept = [%S]", it) }
+        Optional.ofNullable(operationEntry.value.requestBody)
+            .map { it.content }
+            .flatMap(::getMediaType)
+            .map { it.key }
+            .filter { it.isNotBlank() && it != "application/json" }
+            .ifPresent { builder.addMember("contentType = %S", it) }
+        return builder.build()
     }
 
     private fun isIncludeRequest(operation: Operation): Boolean =

--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -96,7 +96,9 @@ class KotlinTypeDefiner internal constructor(
                     "date" == schema.format -> LocalDate::class.asTypeName()
                     "date-time" == schema.format -> ZonedDateTime::class.asTypeName()
                     "uuid" == schema.format -> UUID::class.asTypeName()
-                    "binary" == schema.format -> MultipartFile::class.asTypeName()
+                    "binary" == schema.format -> if (params.framework == Framework.QUARKUS)
+                        ClassName("org.jboss.resteasy.reactive.multipart", "FileUpload")
+                    else MultipartFile::class.asTypeName()
                     schema.enum != null -> {
                         //internal enum
                         val simpleName = getEnumName(schema, typeNameFallback)

--- a/src/main/java/ru/curs/hurdygurdy/Role.java
+++ b/src/main/java/ru/curs/hurdygurdy/Role.java
@@ -1,28 +1,60 @@
 package ru.curs.hurdygurdy;
 
+import java.util.EnumSet;
 import java.util.Locale;
+import java.util.Set;
 
 /**
- * Whether the generator emits a server resource interface (to be implemented)
- * or a client interface (whose implementation the framework provides).
+ * A kind of interface the generator can emit for the API paths. Any subset of
+ * roles can be generated in a single run; each role gets its own name suffix
+ * ({@code XxxController}, {@code XxxApi}, {@code XxxClient}), all in the
+ * {@code controller} subpackage.
  */
 public enum Role {
-    /** Server resource interface (to be implemented by the application). */
-    SERVER,
-    /** Client interface (whose implementation the framework provides). */
-    CLIENT;
+    /** Server interface, to be implemented by the application. */
+    CONTROLLER("Controller"),
+    /**
+     * Pure contract interface: same framework annotations as the controller,
+     * but without response-related artifacts ({@code HttpServletResponse}
+     * parameter, {@code Response} return type). Suitable as a typed contract
+     * for OpenFeign (Spring) or MicroProfile {@code RestClientBuilder}
+     * (Quarkus), or for hand-written client/test implementations.
+     */
+    API("Api"),
+    /** Client interface whose implementation the framework provides. */
+    CLIENT("Client");
+
+    private final String suffix;
+
+    Role(String suffix) {
+        this.suffix = suffix;
+    }
 
     /**
-     * Parses a role name case-insensitively, defaulting to {@link #SERVER} for a
-     * {@code null} or blank value.
+     * Name suffix appended to the OpenAPI tag to form the interface name.
      *
-     * @param value role name (e.g. {@code "server"} or {@code "client"})
-     * @return the matching role, or {@link #SERVER} when unspecified
+     * @return the suffix, e.g. {@code "Controller"}
      */
-    public static Role of(String value) {
-        if (value == null || value.isBlank()) {
-            return SERVER;
+    public String getSuffix() {
+        return suffix;
+    }
+
+    /**
+     * Parses a comma-separated list of role names case-insensitively,
+     * defaulting to {@link #CONTROLLER} for a {@code null} or blank value.
+     *
+     * @param value role names, e.g. {@code "controller,client"}
+     * @return the matching roles, or {@code {CONTROLLER}} when unspecified
+     */
+    public static Set<Role> parse(String value) {
+        EnumSet<Role> result = EnumSet.noneOf(Role.class);
+        if (value != null) {
+            for (String name : value.split(",")) {
+                if (!name.isBlank()) {
+                    result.add(Role.valueOf(name.trim().toUpperCase(Locale.ROOT)));
+                }
+            }
         }
-        return Role.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        return result.isEmpty() ? EnumSet.of(CONTROLLER) : result;
     }
 }

--- a/src/main/java/ru/curs/hurdygurdy/Role.java
+++ b/src/main/java/ru/curs/hurdygurdy/Role.java
@@ -1,0 +1,28 @@
+package ru.curs.hurdygurdy;
+
+import java.util.Locale;
+
+/**
+ * Whether the generator emits a server resource interface (to be implemented)
+ * or a client interface (whose implementation the framework provides).
+ */
+public enum Role {
+    /** Server resource interface (to be implemented by the application). */
+    SERVER,
+    /** Client interface (whose implementation the framework provides). */
+    CLIENT;
+
+    /**
+     * Parses a role name case-insensitively, defaulting to {@link #SERVER} for a
+     * {@code null} or blank value.
+     *
+     * @param value role name (e.g. {@code "server"} or {@code "client"})
+     * @return the matching role, or {@link #SERVER} when unspecified
+     */
+    public static Role of(String value) {
+        if (value == null || value.isBlank()) {
+            return SERVER;
+        }
+        return Role.valueOf(value.trim().toUpperCase(Locale.ROOT));
+    }
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.dictionarySupport2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.dictionarySupport2.approved.txt
@@ -7,89 +7,44 @@
 ---
 /com/example/controller
 ---
-/com/example/controller/Client.java
+/com/example/controller/Controller.java
 package com.example.controller;
 
 import com.example.dto.PlayerActivitiesDTO;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Response;
-import java.lang.Integer;
-import java.lang.String;
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-
-@Path("")
-@RegisterRestClient
-public interface Client {
-  /**
-   * @return a Response whose entity is expected to be empty (no body)
-   */
-  @POST
-  @Path("/api/v1/activity")
-  @Consumes("application/json")
-  Response syncPlayerActivities(PlayerActivitiesDTO request);
-
-  /**
-   * @return a Response whose entity is expected to be java.lang.String
-   */
-  @GET
-  @Path("/api/v1/hello")
-  @Produces("*/*")
-  Response hello();
-
-  /**
-   * @return a Response whose entity is expected to be java.lang.String
-   */
-  @GET
-  @Path("/api/v1/hello/{id}")
-  @Produces("*/*")
-  Response hello(@PathParam("id") int id, @QueryParam("foo") String foo,
-      @QueryParam("bar") Integer bar, @HeaderParam("baz") String baz);
-}
----
-/com/example/controller/PlayerClient.java
-package com.example.controller;
-
 import com.example.dto.PlayersDTO;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Response;
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import com.example.dto.PromoDTO;
+import com.example.dto.TagsDTO;
+import java.lang.String;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
-@Path("")
-@RegisterRestClient
-public interface PlayerClient {
-  /**
-   * @return a Response whose entity is expected to be empty (no body)
-   */
-  @POST
-  @Path("/api/v1/players")
-  @Consumes("application/json")
-  Response syncPlayers(PlayersDTO request);
+interface Controller {
+  @PostMapping("/api/v1/players")
+  void syncPlayers(@RequestBody PlayersDTO request, HttpServletResponse response);
+
+  @PostMapping("/api/v1/activity")
+  void syncPlayerActivities(@RequestBody PlayerActivitiesDTO request, HttpServletResponse response);
+
+  @GetMapping(
+      value = "/api/v1/hello",
+      produces = "*/*"
+  )
+  String hello(HttpServletResponse response);
+
+  @GetMapping(
+      value = "/api/v1/promo/{name}",
+      produces = "application/json"
+  )
+  PromoDTO getPromo(@PathVariable(name = "name") String name, HttpServletResponse response);
+
+  @PostMapping("/api/v1/tags")
+  void postTags(@RequestBody TagsDTO request, HttpServletResponse response);
 }
 ---
 /com/example/dto
----
-/com/example/dto/Car.java
-package com.example.dto;
-
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import java.lang.String;
-import lombok.Data;
-
-@Data
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class Car extends Vehicle {
-  private String carProperty;
-}
 ---
 /com/example/dto/DepositDTO.java
 package com.example.dto;
@@ -108,8 +63,6 @@ import lombok.Data;
 public class DepositDTO {
   private PlayerDTO player;
 
-  private PlayerEnum playerenum;
-
   private String depositId;
 
   private Long amountCents;
@@ -123,17 +76,33 @@ public class DepositDTO {
   private ZonedDateTime processedAt;
 }
 ---
-/com/example/dto/Parent.java
+/com/example/dto/ErrorDTO.java
 package com.example.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
 import lombok.Data;
 
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class Parent {
-  private Vehicle vehicle;
+public class ErrorDTO {
+  private String className;
+
+  private String id;
+
+  private String message;
+}
+---
+/com/example/dto/Gender.java
+package com.example.dto;
+
+public enum Gender {
+  m,
+
+  f,
+
+  n
 }
 ---
 /com/example/dto/PlayerActivitiesDTO.java
@@ -187,6 +156,8 @@ public class PlayerActivityDTO {
   private String userId;
 
   private String currency;
+
+  private Long winsSumCents;
 
   private Long betsSumCents;
 
@@ -257,30 +228,6 @@ public class PlayerDTO {
   private ZonedDateTime signUpAt;
 
   private boolean duplicate;
-
-  public enum Gender {
-    m,
-
-    f,
-
-    n
-  }
-}
----
-/com/example/dto/PlayerEnum.java
-package com.example.dto;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-public enum PlayerEnum {
-  @JsonProperty("good")
-  GOOD,
-
-  @JsonProperty("bad")
-  BAD,
-
-  @JsonProperty("ugly")
-  UGLY
 }
 ---
 /com/example/dto/PlayersDTO.java
@@ -297,40 +244,56 @@ public class PlayersDTO {
   private List<PlayerDTO> players;
 }
 ---
-/com/example/dto/Truck.java
+/com/example/dto/PromoDTO.java
 package com.example.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.Integer;
 import java.lang.String;
 import lombok.Data;
 
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class Truck extends Vehicle {
-  private String truckProperty;
+public class PromoDTO {
+  private Integer id;
+
+  private String name;
+
+  private String landingUrl;
 }
 ---
-/com/example/dto/Vehicle.java
+/com/example/dto/TagDTO.java
 package com.example.dto;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.Integer;
+import java.lang.String;
 import lombok.Data;
 
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    include = JsonTypeInfo.As.PROPERTY,
-    property = "vehicle_type"
-)
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = Car.class, name = "CAR"),
-    @JsonSubTypes.Type(value = Truck.class, name = "TRUCK")})
-public class Vehicle {
+public class TagDTO {
+  private Integer promoId;
+
+  private String tag;
+
+  private String ip;
+}
+---
+/com/example/dto/TagsDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TagsDTO {
+  private List<TagDTO> items;
 }
 ---
 /com/example/dto/ZonedDateTimeDeserializer.java
@@ -357,12 +320,6 @@ public class ZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
       return ZonedDateTime.parse(date, formatter);
     }
     catch (DateTimeException e) {
-      try  {
-        return ZonedDateTime.parse(date + "Z", formatter);
-      }
-      catch (DateTimeException ignored) {
-        // do nothing, exception thrown below
-      }
       throw new JsonParseException(jsonParser, e.getMessage());
     }
   }

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.externalReturnType.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.externalReturnType.approved.txt
@@ -1,0 +1,23 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/LicenseController.java
+package com.example.controller;
+
+import com.example.collector.api.dto.LicenseResponse;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+
+interface LicenseController {
+  @GetMapping(
+      value = "/api/v1/admin/license",
+      produces = "application/json"
+  )
+  LicenseResponse getLicenseInfo(HttpServletResponse response);
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -37,7 +37,7 @@ class CodegenTest {
     void doNotGenerateResponseParameter() throws IOException {
         codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
                 .generateResponseParameter(false)
-                .generateApiInterface(true));
+                .generate(Role.CONTROLLER, Role.API));
         codegen.generate(Path.of("src/test/resources/sample1.yaml"), result);
         // Snapshot only: see generateSample1 — references external types.
         Approvals.verify(getContent(result));

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -144,7 +144,7 @@ class CodegenTest {
     void springClientSample2() throws IOException {
         codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
                 .generateResponseParameter(true)
-                .framework(Framework.SPRING).role(Role.CLIENT));
+                .framework(Framework.SPRING).generate(Role.CLIENT));
         codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
         verify(result);
     }
@@ -153,7 +153,7 @@ class CodegenTest {
     void quarkusClientSample2() throws IOException {
         codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
                 .generateResponseParameter(true)
-                .framework(Framework.QUARKUS).role(Role.CLIENT));
+                .framework(Framework.QUARKUS).generate(Role.CLIENT));
         codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
         verify(result);
     }
@@ -162,10 +162,31 @@ class CodegenTest {
     void quarkusClientMultipart() throws IOException {
         codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
                 .generateResponseParameter(true)
-                .framework(Framework.QUARKUS).role(Role.CLIENT));
+                .framework(Framework.QUARKUS).generate(Role.CLIENT));
         codegen.generate(Path.of("src/test/resources/multipart.yaml"), result);
         // Snapshot only: @RestForm would require the resteasy-reactive artifact to compile.
         Approvals.verify(getContent(result));
+    }
+
+    @Test
+    void quarkusServerAndClientSample2() throws IOException {
+        // Both roles in a single run: XxxController (server resource) and
+        // XxxClient (@RegisterRestClient) side by side, sharing the DTOs.
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS)
+                .generate(Role.CONTROLLER, Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void springAllRolesSample2() throws IOException {
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .generate(Role.CONTROLLER, Role.API, Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
     }
 
     @Test

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -141,6 +141,34 @@ class CodegenTest {
     }
 
     @Test
+    void springClientSample2() throws IOException {
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.SPRING).role(Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void quarkusClientSample2() throws IOException {
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS).role(Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void quarkusClientMultipart() throws IOException {
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS).role(Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/multipart.yaml"), result);
+        // Snapshot only: @RestForm would require the resteasy-reactive artifact to compile.
+        Approvals.verify(getContent(result));
+    }
+
+    @Test
     void inheritedDiscriminatorProperty() throws IOException {
         codegen.generate(Path.of("src/test/resources/matchconfig.yaml"), result);
         verify(result);

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -112,6 +112,35 @@ class CodegenTest {
     }
 
     @Test
+    void quarkusGenerateSample2() throws IOException {
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void quarkusDoNotGenerateResponseParameter() throws IOException {
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(false)
+                .framework(Framework.QUARKUS));
+        codegen.generate(Path.of("src/test/resources/commonparam.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void quarkusMultipart() throws IOException {
+        codegen = new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS));
+        codegen.generate(Path.of("src/test/resources/multipart.yaml"), result);
+        // Snapshot only: compiling the generated @RestForm parameter would require
+        // the resteasy-reactive artifact, which we deliberately do not depend on.
+        Approvals.verify(getContent(result));
+    }
+
+    @Test
     void inheritedDiscriminatorProperty() throws IOException {
         codegen.generate(Path.of("src/test/resources/matchconfig.yaml"), result);
         verify(result);

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusClientMultipart.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusClientMultipart.approved.txt
@@ -1,0 +1,53 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.RunWorkflowRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+@Path("")
+@RegisterRestClient
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be com.example.dto.RunWorkflowRequest
+   */
+  @POST
+  @Path("/api/v1/workflow-run")
+  @Produces("application/json")
+  @Consumes("multipart/form-data")
+  Response runWorkflow(@RestForm("runWorkflowRequest") RunWorkflowRequest runWorkflowRequest,
+      @RestForm("config") FileUpload config);
+}
+---
+/com/example/dto
+---
+/com/example/dto/RunWorkflowRequest.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class RunWorkflowRequest {
+  private String inputConnection;
+
+  private String outputConnection;
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusClientMultipart.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusClientMultipart.approved.txt
@@ -7,7 +7,7 @@
 ---
 /com/example/controller
 ---
-/com/example/controller/Controller.java
+/com/example/controller/Client.java
 package com.example.controller;
 
 import com.example.dto.RunWorkflowRequest;
@@ -22,7 +22,7 @@ import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 @Path("")
 @RegisterRestClient
-public interface Controller {
+public interface Client {
   /**
    * @return a Response whose entity is expected to be com.example.dto.RunWorkflowRequest
    */

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusClientSample2.approved.txt
@@ -1,0 +1,390 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.PlayerActivitiesDTO;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import java.lang.Integer;
+import java.lang.String;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("")
+@RegisterRestClient
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/activity")
+  @Consumes("application/json")
+  Response syncPlayerActivities(PlayerActivitiesDTO request);
+
+  /**
+   * @return a Response whose entity is expected to be java.lang.String
+   */
+  @GET
+  @Path("/api/v1/hello")
+  @Produces("*/*")
+  Response hello();
+
+  /**
+   * @return a Response whose entity is expected to be java.lang.String
+   */
+  @GET
+  @Path("/api/v1/hello/{id}")
+  @Produces("*/*")
+  Response hello(@PathParam("id") int id, @QueryParam("foo") String foo,
+      @QueryParam("bar") Integer bar, @HeaderParam("baz") String baz);
+}
+---
+/com/example/controller/PlayerController.java
+package com.example.controller;
+
+import com.example.dto.PlayersDTO;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("")
+@RegisterRestClient
+public interface PlayerController {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/players")
+  @Consumes("application/json")
+  Response syncPlayers(PlayersDTO request);
+}
+---
+/com/example/dto
+---
+/com/example/dto/Car.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Car extends Vehicle {
+  private String carProperty;
+}
+---
+/com/example/dto/DepositDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.Long;
+import java.lang.String;
+import java.time.ZonedDateTime;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DepositDTO {
+  private PlayerDTO player;
+
+  private PlayerEnum playerenum;
+
+  private String depositId;
+
+  private Long amountCents;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime processedAt;
+}
+---
+/com/example/dto/Parent.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Parent {
+  private Vehicle vehicle;
+}
+---
+/com/example/dto/PlayerActivitiesDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerActivitiesDTO {
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime from;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime to;
+
+  private List<PlayerActivityDTO> items;
+}
+---
+/com/example/dto/PlayerActivityDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.Long;
+import java.lang.String;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerActivityDTO {
+  private String tag;
+
+  private String userId;
+
+  private String currency;
+
+  private Long betsSumCents;
+
+  private Long wagerCents;
+
+  private Long additionalDeductionsSumCents;
+
+  private Long roundsCount;
+
+  private Long bonusIssuesSumCents;
+
+  private Long chargebacksSumCents;
+
+  private Long chargebacksCount;
+
+  private Long depositsSumCents;
+
+  private Long depositsCount;
+
+  private Long cashoutsSumCents;
+
+  private Long cashoutsCount;
+
+  private List<DepositDTO> deposits;
+}
+---
+/com/example/dto/PlayerDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.String;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerDTO {
+  private String tag;
+
+  private String email;
+
+  private String userId;
+
+  private LocalDate dateOfBirth;
+
+  private String firstName;
+
+  private String lastName;
+
+  private String nickname;
+
+  private Gender gender;
+
+  private String country;
+
+  private String language;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime signUpAt;
+
+  private boolean duplicate;
+
+  public enum Gender {
+    m,
+
+    f,
+
+    n
+  }
+}
+---
+/com/example/dto/PlayerEnum.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum PlayerEnum {
+  @JsonProperty("good")
+  GOOD,
+
+  @JsonProperty("bad")
+  BAD,
+
+  @JsonProperty("ugly")
+  UGLY
+}
+---
+/com/example/dto/PlayersDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayersDTO {
+  private List<PlayerDTO> players;
+}
+---
+/com/example/dto/Truck.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Truck extends Vehicle {
+  private String truckProperty;
+}
+---
+/com/example/dto/Vehicle.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "vehicle_type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Car.class, name = "CAR"),
+    @JsonSubTypes.Type(value = Truck.class, name = "TRUCK")})
+public class Vehicle {
+}
+---
+/com/example/dto/ZonedDateTimeDeserializer.java
+package com.example.dto;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.lang.Override;
+import java.time.DateTimeException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
+  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+  @Override
+  public ZonedDateTime deserialize(JsonParser jsonParser,
+      DeserializationContext deserializationContext) throws IOException {
+    String date = jsonParser.getText();
+    try  {
+      return ZonedDateTime.parse(date, formatter);
+    }
+    catch (DateTimeException e) {
+      try  {
+        return ZonedDateTime.parse(date + "Z", formatter);
+      }
+      catch (DateTimeException ignored) {
+        // do nothing, exception thrown below
+      }
+      throw new JsonParseException(jsonParser, e.getMessage());
+    }
+  }
+}
+---
+/com/example/dto/ZonedDateTimeSerializer.java
+package com.example.dto;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.lang.Override;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ZonedDateTimeSerializer extends JsonSerializer<ZonedDateTime> {
+  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+  @Override
+  public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(formatter.format(value));
+  }
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusDoNotGenerateResponseParameter.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusDoNotGenerateResponseParameter.approved.txt
@@ -1,0 +1,49 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.ToveDTO;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+
+@Path("")
+public interface Controller {
+  @GET
+  @Path("/api/v1/tove/{id}")
+  @Produces("application/json")
+  ToveDTO getTove(@PathParam("id") int id);
+
+  @PUT
+  @Path("/api/v1/tove/{id}")
+  @Produces("application/json")
+  @Consumes("application/json")
+  ToveDTO updateTove(ToveDTO request, @PathParam("id") int id);
+}
+---
+/com/example/dto
+---
+/com/example/dto/ToveDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ToveDTO {
+  private String name;
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusGenerateSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusGenerateSample2.approved.txt
@@ -1,0 +1,388 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.PlayerActivitiesDTO;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import java.lang.Integer;
+import java.lang.String;
+
+@Path("")
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/activity")
+  @Consumes("application/json")
+  Response syncPlayerActivities(PlayerActivitiesDTO request);
+
+  /**
+   * @return a Response whose entity is expected to be java.lang.String
+   */
+  @GET
+  @Path("/api/v1/hello")
+  @Produces("*/*")
+  Response hello(@Context ContainerRequestContext requestContext);
+
+  /**
+   * @return a Response whose entity is expected to be java.lang.String
+   */
+  @GET
+  @Path("/api/v1/hello/{id}")
+  @Produces("*/*")
+  Response hello(@PathParam("id") int id, @QueryParam("foo") String foo,
+      @QueryParam("bar") Integer bar, @HeaderParam("baz") String baz);
+}
+---
+/com/example/controller/PlayerController.java
+package com.example.controller;
+
+import com.example.dto.PlayersDTO;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("")
+public interface PlayerController {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/players")
+  @Consumes("application/json")
+  Response syncPlayers(PlayersDTO request);
+}
+---
+/com/example/dto
+---
+/com/example/dto/Car.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Car extends Vehicle {
+  private String carProperty;
+}
+---
+/com/example/dto/DepositDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.Long;
+import java.lang.String;
+import java.time.ZonedDateTime;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DepositDTO {
+  private PlayerDTO player;
+
+  private PlayerEnum playerenum;
+
+  private String depositId;
+
+  private Long amountCents;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime processedAt;
+}
+---
+/com/example/dto/Parent.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Parent {
+  private Vehicle vehicle;
+}
+---
+/com/example/dto/PlayerActivitiesDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerActivitiesDTO {
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime from;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime to;
+
+  private List<PlayerActivityDTO> items;
+}
+---
+/com/example/dto/PlayerActivityDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.Long;
+import java.lang.String;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerActivityDTO {
+  private String tag;
+
+  private String userId;
+
+  private String currency;
+
+  private Long betsSumCents;
+
+  private Long wagerCents;
+
+  private Long additionalDeductionsSumCents;
+
+  private Long roundsCount;
+
+  private Long bonusIssuesSumCents;
+
+  private Long chargebacksSumCents;
+
+  private Long chargebacksCount;
+
+  private Long depositsSumCents;
+
+  private Long depositsCount;
+
+  private Long cashoutsSumCents;
+
+  private Long cashoutsCount;
+
+  private List<DepositDTO> deposits;
+}
+---
+/com/example/dto/PlayerDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.String;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerDTO {
+  private String tag;
+
+  private String email;
+
+  private String userId;
+
+  private LocalDate dateOfBirth;
+
+  private String firstName;
+
+  private String lastName;
+
+  private String nickname;
+
+  private Gender gender;
+
+  private String country;
+
+  private String language;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime signUpAt;
+
+  private boolean duplicate;
+
+  public enum Gender {
+    m,
+
+    f,
+
+    n
+  }
+}
+---
+/com/example/dto/PlayerEnum.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum PlayerEnum {
+  @JsonProperty("good")
+  GOOD,
+
+  @JsonProperty("bad")
+  BAD,
+
+  @JsonProperty("ugly")
+  UGLY
+}
+---
+/com/example/dto/PlayersDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayersDTO {
+  private List<PlayerDTO> players;
+}
+---
+/com/example/dto/Truck.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Truck extends Vehicle {
+  private String truckProperty;
+}
+---
+/com/example/dto/Vehicle.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "vehicle_type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Car.class, name = "CAR"),
+    @JsonSubTypes.Type(value = Truck.class, name = "TRUCK")})
+public class Vehicle {
+}
+---
+/com/example/dto/ZonedDateTimeDeserializer.java
+package com.example.dto;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.lang.Override;
+import java.time.DateTimeException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
+  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+  @Override
+  public ZonedDateTime deserialize(JsonParser jsonParser,
+      DeserializationContext deserializationContext) throws IOException {
+    String date = jsonParser.getText();
+    try  {
+      return ZonedDateTime.parse(date, formatter);
+    }
+    catch (DateTimeException e) {
+      try  {
+        return ZonedDateTime.parse(date + "Z", formatter);
+      }
+      catch (DateTimeException ignored) {
+        // do nothing, exception thrown below
+      }
+      throw new JsonParseException(jsonParser, e.getMessage());
+    }
+  }
+}
+---
+/com/example/dto/ZonedDateTimeSerializer.java
+package com.example.dto;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.lang.Override;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ZonedDateTimeSerializer extends JsonSerializer<ZonedDateTime> {
+  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+  @Override
+  public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(formatter.format(value));
+  }
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusMultipart.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusMultipart.approved.txt
@@ -1,0 +1,51 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.RunWorkflowRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestForm;
+import org.springframework.web.multipart.MultipartFile;
+
+@Path("")
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be com.example.dto.RunWorkflowRequest
+   */
+  @POST
+  @Path("/api/v1/workflow-run")
+  @Produces("application/json")
+  @Consumes("multipart/form-data")
+  Response runWorkflow(@RestForm("runWorkflowRequest") RunWorkflowRequest runWorkflowRequest,
+      @RestForm("config") MultipartFile config);
+}
+---
+/com/example/dto
+---
+/com/example/dto/RunWorkflowRequest.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class RunWorkflowRequest {
+  private String inputConnection;
+
+  private String outputConnection;
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusMultipart.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusMultipart.approved.txt
@@ -17,7 +17,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestForm;
-import org.springframework.web.multipart.MultipartFile;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 @Path("")
 public interface Controller {
@@ -29,7 +29,7 @@ public interface Controller {
   @Produces("application/json")
   @Consumes("multipart/form-data")
   Response runWorkflow(@RestForm("runWorkflowRequest") RunWorkflowRequest runWorkflowRequest,
-      @RestForm("config") MultipartFile config);
+      @RestForm("config") FileUpload config);
 }
 ---
 /com/example/dto

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusServerAndClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusServerAndClientSample2.approved.txt
@@ -53,6 +53,52 @@ public interface Client {
       @QueryParam("bar") Integer bar, @HeaderParam("baz") String baz);
 }
 ---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.PlayerActivitiesDTO;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import java.lang.Integer;
+import java.lang.String;
+
+@Path("")
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/activity")
+  @Consumes("application/json")
+  Response syncPlayerActivities(PlayerActivitiesDTO request);
+
+  /**
+   * @return a Response whose entity is expected to be java.lang.String
+   */
+  @GET
+  @Path("/api/v1/hello")
+  @Produces("*/*")
+  Response hello(@Context ContainerRequestContext requestContext);
+
+  /**
+   * @return a Response whose entity is expected to be java.lang.String
+   */
+  @GET
+  @Path("/api/v1/hello/{id}")
+  @Produces("*/*")
+  Response hello(@PathParam("id") int id, @QueryParam("foo") String foo,
+      @QueryParam("bar") Integer bar, @HeaderParam("baz") String baz);
+}
+---
 /com/example/controller/PlayerClient.java
 package com.example.controller;
 
@@ -66,6 +112,26 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @Path("")
 @RegisterRestClient
 public interface PlayerClient {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/players")
+  @Consumes("application/json")
+  Response syncPlayers(PlayersDTO request);
+}
+---
+/com/example/controller/PlayerController.java
+package com.example.controller;
+
+import com.example.dto.PlayersDTO;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("")
+public interface PlayerController {
   /**
    * @return a Response whose entity is expected to be empty (no body)
    */

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.springAllRolesSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.springAllRolesSample2.approved.txt
@@ -7,72 +7,146 @@
 ---
 /com/example/controller
 ---
+/com/example/controller/Api.java
+package com.example.controller;
+
+import com.example.dto.PlayerActivitiesDTO;
+import java.lang.Integer;
+import java.lang.String;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface Api {
+  @PostMapping("/api/v1/activity")
+  void syncPlayerActivities(@RequestBody PlayerActivitiesDTO request);
+
+  @GetMapping(
+      value = "/api/v1/hello",
+      produces = "*/*"
+  )
+  String hello();
+
+  @GetMapping(
+      value = "/api/v1/hello/{id}",
+      produces = "*/*"
+  )
+  String hello(@PathVariable(name = "id") int id,
+      @RequestParam(required = false, name = "foo") String foo,
+      @RequestParam(required = true, name = "bar") Integer bar,
+      @RequestHeader(required = true, name = "baz") String baz);
+}
+---
 /com/example/controller/Client.java
 package com.example.controller;
 
 import com.example.dto.PlayerActivitiesDTO;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Response;
 import java.lang.Integer;
 import java.lang.String;
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import java.lang.Void;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
 
-@Path("")
-@RegisterRestClient
 public interface Client {
-  /**
-   * @return a Response whose entity is expected to be empty (no body)
-   */
-  @POST
-  @Path("/api/v1/activity")
-  @Consumes("application/json")
-  Response syncPlayerActivities(PlayerActivitiesDTO request);
+  @PostExchange("/api/v1/activity")
+  ResponseEntity<Void> syncPlayerActivities(@RequestBody PlayerActivitiesDTO request);
 
-  /**
-   * @return a Response whose entity is expected to be java.lang.String
-   */
-  @GET
-  @Path("/api/v1/hello")
-  @Produces("*/*")
-  Response hello();
+  @GetExchange(
+      value = "/api/v1/hello",
+      accept = "*/*"
+  )
+  ResponseEntity<String> hello();
 
-  /**
-   * @return a Response whose entity is expected to be java.lang.String
-   */
-  @GET
-  @Path("/api/v1/hello/{id}")
-  @Produces("*/*")
-  Response hello(@PathParam("id") int id, @QueryParam("foo") String foo,
-      @QueryParam("bar") Integer bar, @HeaderParam("baz") String baz);
+  @GetExchange(
+      value = "/api/v1/hello/{id}",
+      accept = "*/*"
+  )
+  ResponseEntity<String> hello(@PathVariable(name = "id") int id,
+      @RequestParam(required = false, name = "foo") String foo,
+      @RequestParam(required = true, name = "bar") Integer bar,
+      @RequestHeader(required = true, name = "baz") String baz);
+}
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.PlayerActivitiesDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.Integer;
+import java.lang.String;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface Controller {
+  @PostMapping("/api/v1/activity")
+  void syncPlayerActivities(@RequestBody PlayerActivitiesDTO request, HttpServletResponse response);
+
+  @GetMapping(
+      value = "/api/v1/hello",
+      produces = "*/*"
+  )
+  String hello(HttpServletRequest request, HttpServletResponse response);
+
+  @GetMapping(
+      value = "/api/v1/hello/{id}",
+      produces = "*/*"
+  )
+  String hello(@PathVariable(name = "id") int id,
+      @RequestParam(required = false, name = "foo") String foo,
+      @RequestParam(required = true, name = "bar") Integer bar,
+      @RequestHeader(required = true, name = "baz") String baz, HttpServletResponse response);
+}
+---
+/com/example/controller/PlayerApi.java
+package com.example.controller;
+
+import com.example.dto.PlayersDTO;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface PlayerApi {
+  @PostMapping("/api/v1/players")
+  void syncPlayers(@RequestBody PlayersDTO request);
 }
 ---
 /com/example/controller/PlayerClient.java
 package com.example.controller;
 
 import com.example.dto.PlayersDTO;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Response;
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import java.lang.Void;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
 
-@Path("")
-@RegisterRestClient
 public interface PlayerClient {
-  /**
-   * @return a Response whose entity is expected to be empty (no body)
-   */
-  @POST
-  @Path("/api/v1/players")
-  @Consumes("application/json")
-  Response syncPlayers(PlayersDTO request);
+  @PostExchange("/api/v1/players")
+  ResponseEntity<Void> syncPlayers(@RequestBody PlayersDTO request);
+}
+---
+/com/example/controller/PlayerController.java
+package com.example.controller;
+
+import com.example.dto.PlayersDTO;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface PlayerController {
+  @PostMapping("/api/v1/players")
+  void syncPlayers(@RequestBody PlayersDTO request, HttpServletResponse response);
 }
 ---
 /com/example/dto

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.springClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.springClientSample2.approved.txt
@@ -7,7 +7,7 @@
 ---
 /com/example/controller
 ---
-/com/example/controller/Controller.java
+/com/example/controller/Client.java
 package com.example.controller;
 
 import com.example.dto.PlayerActivitiesDTO;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
-public interface Controller {
+public interface Client {
   @PostExchange("/api/v1/activity")
   ResponseEntity<Void> syncPlayerActivities(@RequestBody PlayerActivitiesDTO request);
 
@@ -42,7 +42,7 @@ public interface Controller {
       @RequestHeader(required = true, name = "baz") String baz);
 }
 ---
-/com/example/controller/PlayerController.java
+/com/example/controller/PlayerClient.java
 package com.example.controller;
 
 import com.example.dto.PlayersDTO;
@@ -51,7 +51,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.service.annotation.PostExchange;
 
-public interface PlayerController {
+public interface PlayerClient {
   @PostExchange("/api/v1/players")
   ResponseEntity<Void> syncPlayers(@RequestBody PlayersDTO request);
 }

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.springClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.springClientSample2.approved.txt
@@ -1,0 +1,371 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import com.example.dto.PlayerActivitiesDTO;
+import java.lang.Integer;
+import java.lang.String;
+import java.lang.Void;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface Controller {
+  @PostExchange("/api/v1/activity")
+  ResponseEntity<Void> syncPlayerActivities(@RequestBody PlayerActivitiesDTO request);
+
+  @GetExchange(
+      value = "/api/v1/hello",
+      accept = "*/*"
+  )
+  ResponseEntity<String> hello();
+
+  @GetExchange(
+      value = "/api/v1/hello/{id}",
+      accept = "*/*"
+  )
+  ResponseEntity<String> hello(@PathVariable(name = "id") int id,
+      @RequestParam(required = false, name = "foo") String foo,
+      @RequestParam(required = true, name = "bar") Integer bar,
+      @RequestHeader(required = true, name = "baz") String baz);
+}
+---
+/com/example/controller/PlayerController.java
+package com.example.controller;
+
+import com.example.dto.PlayersDTO;
+import java.lang.Void;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface PlayerController {
+  @PostExchange("/api/v1/players")
+  ResponseEntity<Void> syncPlayers(@RequestBody PlayersDTO request);
+}
+---
+/com/example/dto
+---
+/com/example/dto/Car.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Car extends Vehicle {
+  private String carProperty;
+}
+---
+/com/example/dto/DepositDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.Long;
+import java.lang.String;
+import java.time.ZonedDateTime;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DepositDTO {
+  private PlayerDTO player;
+
+  private PlayerEnum playerenum;
+
+  private String depositId;
+
+  private Long amountCents;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime processedAt;
+}
+---
+/com/example/dto/Parent.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Parent {
+  private Vehicle vehicle;
+}
+---
+/com/example/dto/PlayerActivitiesDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerActivitiesDTO {
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime from;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime to;
+
+  private List<PlayerActivityDTO> items;
+}
+---
+/com/example/dto/PlayerActivityDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.Long;
+import java.lang.String;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerActivityDTO {
+  private String tag;
+
+  private String userId;
+
+  private String currency;
+
+  private Long betsSumCents;
+
+  private Long wagerCents;
+
+  private Long additionalDeductionsSumCents;
+
+  private Long roundsCount;
+
+  private Long bonusIssuesSumCents;
+
+  private Long chargebacksSumCents;
+
+  private Long chargebacksCount;
+
+  private Long depositsSumCents;
+
+  private Long depositsCount;
+
+  private Long cashoutsSumCents;
+
+  private Long cashoutsCount;
+
+  private List<DepositDTO> deposits;
+}
+---
+/com/example/dto/PlayerDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.String;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayerDTO {
+  private String tag;
+
+  private String email;
+
+  private String userId;
+
+  private LocalDate dateOfBirth;
+
+  private String firstName;
+
+  private String lastName;
+
+  private String nickname;
+
+  private Gender gender;
+
+  private String country;
+
+  private String language;
+
+  @JsonDeserialize(
+      using = ZonedDateTimeDeserializer.class
+  )
+  @JsonSerialize(
+      using = ZonedDateTimeSerializer.class
+  )
+  private ZonedDateTime signUpAt;
+
+  private boolean duplicate;
+
+  public enum Gender {
+    m,
+
+    f,
+
+    n
+  }
+}
+---
+/com/example/dto/PlayerEnum.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum PlayerEnum {
+  @JsonProperty("good")
+  GOOD,
+
+  @JsonProperty("bad")
+  BAD,
+
+  @JsonProperty("ugly")
+  UGLY
+}
+---
+/com/example/dto/PlayersDTO.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlayersDTO {
+  private List<PlayerDTO> players;
+}
+---
+/com/example/dto/Truck.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Truck extends Vehicle {
+  private String truckProperty;
+}
+---
+/com/example/dto/Vehicle.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "vehicle_type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Car.class, name = "CAR"),
+    @JsonSubTypes.Type(value = Truck.class, name = "TRUCK")})
+public class Vehicle {
+}
+---
+/com/example/dto/ZonedDateTimeDeserializer.java
+package com.example.dto;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.lang.Override;
+import java.time.DateTimeException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
+  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+  @Override
+  public ZonedDateTime deserialize(JsonParser jsonParser,
+      DeserializationContext deserializationContext) throws IOException {
+    String date = jsonParser.getText();
+    try  {
+      return ZonedDateTime.parse(date, formatter);
+    }
+    catch (DateTimeException e) {
+      try  {
+        return ZonedDateTime.parse(date + "Z", formatter);
+      }
+      catch (DateTimeException ignored) {
+        // do nothing, exception thrown below
+      }
+      throw new JsonParseException(jsonParser, e.getMessage());
+    }
+  }
+}
+---
+/com/example/dto/ZonedDateTimeSerializer.java
+package com.example.dto;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.lang.Override;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ZonedDateTimeSerializer extends JsonSerializer<ZonedDateTime> {
+  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+  @Override
+  public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(formatter.format(value));
+  }
+}

--- a/src/test/java/ru/curs/hurdygurdy/DateSerdeTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/DateSerdeTest.java
@@ -59,7 +59,7 @@ class DateSerdeTest {
     }
 
     @SuppressWarnings("unchecked")
-    private void assertRoundTrips(URLClassLoader loader) throws Exception {
+    private void assertRoundTrips(URLClassLoader loader) {
         JsonSerializer<ZonedDateTime> serializer = (JsonSerializer<ZonedDateTime>)
                 loader.loadClass(SER).getDeclaredConstructor().newInstance();
         JsonDeserializer<ZonedDateTime> deserializer = (JsonDeserializer<ZonedDateTime>)

--- a/src/test/java/ru/curs/hurdygurdy/DateSerdeTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/DateSerdeTest.java
@@ -59,7 +59,7 @@ class DateSerdeTest {
     }
 
     @SuppressWarnings("unchecked")
-    private void assertRoundTrips(URLClassLoader loader) {
+    private void assertRoundTrips(URLClassLoader loader) throws Exception {
         JsonSerializer<ZonedDateTime> serializer = (JsonSerializer<ZonedDateTime>)
                 loader.loadClass(SER).getDeclaredConstructor().newInstance();
         JsonDeserializer<ZonedDateTime> deserializer = (JsonDeserializer<ZonedDateTime>)

--- a/src/test/java/ru/curs/hurdygurdy/GeneratorParamsTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/GeneratorParamsTest.java
@@ -1,0 +1,34 @@
+package ru.curs.hurdygurdy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeneratorParamsTest {
+
+    @Test
+    void defaultFrameworkIsSpring() {
+        assertThat(GeneratorParams.rootPackage("com.example").getFramework())
+                .isEqualTo(Framework.SPRING);
+    }
+
+    @Test
+    void frameworkIsSettable() {
+        assertThat(GeneratorParams.rootPackage("com.example")
+                .framework(Framework.QUARKUS).getFramework())
+                .isEqualTo(Framework.QUARKUS);
+    }
+
+    @Test
+    void ofParsesCaseInsensitively() {
+        assertThat(Framework.of("quarkus")).isEqualTo(Framework.QUARKUS);
+        assertThat(Framework.of("QUARKUS")).isEqualTo(Framework.QUARKUS);
+        assertThat(Framework.of("spring")).isEqualTo(Framework.SPRING);
+    }
+
+    @Test
+    void ofDefaultsToSpringForBlankOrNull() {
+        assertThat(Framework.of(null)).isEqualTo(Framework.SPRING);
+        assertThat(Framework.of("  ")).isEqualTo(Framework.SPRING);
+    }
+}

--- a/src/test/java/ru/curs/hurdygurdy/GeneratorParamsTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/GeneratorParamsTest.java
@@ -3,6 +3,7 @@ package ru.curs.hurdygurdy;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class GeneratorParamsTest {
 
@@ -33,22 +34,45 @@ class GeneratorParamsTest {
     }
 
     @Test
-    void defaultRoleIsServer() {
-        assertThat(GeneratorParams.rootPackage("com.example").getRole())
-                .isEqualTo(Role.SERVER);
+    void defaultGenerateIsControllerOnly() {
+        assertThat(GeneratorParams.rootPackage("com.example").getGenerate())
+                .containsExactly(Role.CONTROLLER);
     }
 
     @Test
-    void roleIsSettable() {
+    void generateIsSettableAndReplacesSelection() {
         assertThat(GeneratorParams.rootPackage("com.example")
-                .role(Role.CLIENT).getRole()).isEqualTo(Role.CLIENT);
+                .generate(Role.CLIENT).getGenerate())
+                .containsExactly(Role.CLIENT);
+        assertThat(GeneratorParams.rootPackage("com.example")
+                .generate(Role.CONTROLLER, Role.API, Role.CLIENT).getGenerate())
+                .containsExactly(Role.CONTROLLER, Role.API, Role.CLIENT);
     }
 
     @Test
-    void roleOfParsesCaseInsensitivelyAndDefaults() {
-        assertThat(Role.of("client")).isEqualTo(Role.CLIENT);
-        assertThat(Role.of("SERVER")).isEqualTo(Role.SERVER);
-        assertThat(Role.of(null)).isEqualTo(Role.SERVER);
-        assertThat(Role.of("  ")).isEqualTo(Role.SERVER);
+    void generateRejectsEmptySelection() {
+        assertThatThrownBy(() -> GeneratorParams.rootPackage("com.example").generate())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void generateApiInterfaceAddsApiToSelection() {
+        GeneratorParams params = GeneratorParams.rootPackage("com.example")
+                .generateApiInterface(true);
+        assertThat(params.getGenerate()).containsExactly(Role.CONTROLLER, Role.API);
+        assertThat(params.isGenerateApiInterface()).isTrue();
+        params.generateApiInterface(false);
+        assertThat(params.getGenerate()).containsExactly(Role.CONTROLLER);
+        assertThat(params.isGenerateApiInterface()).isFalse();
+    }
+
+    @Test
+    void roleParsesCaseInsensitivelyAndDefaults() {
+        assertThat(Role.parse("client")).containsExactly(Role.CLIENT);
+        assertThat(Role.parse("CONTROLLER, Api")).containsExactly(Role.CONTROLLER, Role.API);
+        assertThat(Role.parse("controller,api,client"))
+                .containsExactly(Role.CONTROLLER, Role.API, Role.CLIENT);
+        assertThat(Role.parse(null)).containsExactly(Role.CONTROLLER);
+        assertThat(Role.parse("  ")).containsExactly(Role.CONTROLLER);
     }
 }

--- a/src/test/java/ru/curs/hurdygurdy/GeneratorParamsTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/GeneratorParamsTest.java
@@ -31,4 +31,24 @@ class GeneratorParamsTest {
         assertThat(Framework.of(null)).isEqualTo(Framework.SPRING);
         assertThat(Framework.of("  ")).isEqualTo(Framework.SPRING);
     }
+
+    @Test
+    void defaultRoleIsServer() {
+        assertThat(GeneratorParams.rootPackage("com.example").getRole())
+                .isEqualTo(Role.SERVER);
+    }
+
+    @Test
+    void roleIsSettable() {
+        assertThat(GeneratorParams.rootPackage("com.example")
+                .role(Role.CLIENT).getRole()).isEqualTo(Role.CLIENT);
+    }
+
+    @Test
+    void roleOfParsesCaseInsensitivelyAndDefaults() {
+        assertThat(Role.of("client")).isEqualTo(Role.CLIENT);
+        assertThat(Role.of("SERVER")).isEqualTo(Role.SERVER);
+        assertThat(Role.of(null)).isEqualTo(Role.SERVER);
+        assertThat(Role.of("  ")).isEqualTo(Role.SERVER);
+    }
 }

--- a/src/test/java/ru/curs/hurdygurdy/GeneratorParamsTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/GeneratorParamsTest.java
@@ -56,14 +56,13 @@ class GeneratorParamsTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void generateApiInterfaceAddsApiToSelection() {
         GeneratorParams params = GeneratorParams.rootPackage("com.example")
                 .generateApiInterface(true);
         assertThat(params.getGenerate()).containsExactly(Role.CONTROLLER, Role.API);
-        assertThat(params.isGenerateApiInterface()).isTrue();
         params.generateApiInterface(false);
         assertThat(params.getGenerate()).containsExactly(Role.CONTROLLER);
-        assertThat(params.isGenerateApiInterface()).isFalse();
     }
 
     @Test

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -199,7 +199,7 @@ class KCodegenTest {
     void springClientSample2() throws IOException {
         codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
                 .generateResponseParameter(true)
-                .framework(Framework.SPRING).role(Role.CLIENT));
+                .framework(Framework.SPRING).generate(Role.CLIENT));
         codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
         verify(result);
     }
@@ -208,7 +208,7 @@ class KCodegenTest {
     void quarkusClientSample2() throws IOException {
         codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
                 .generateResponseParameter(true)
-                .framework(Framework.QUARKUS).role(Role.CLIENT));
+                .framework(Framework.QUARKUS).generate(Role.CLIENT));
         codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
         verify(result);
     }
@@ -217,10 +217,31 @@ class KCodegenTest {
     void quarkusClientMultipart() throws IOException {
         codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
                 .generateResponseParameter(true)
-                .framework(Framework.QUARKUS).role(Role.CLIENT));
+                .framework(Framework.QUARKUS).generate(Role.CLIENT));
         codegen.generate(Path.of("src/test/resources/multipart.yaml"), result);
         // Snapshot only.
         Approvals.verify(getContent(result));
+    }
+
+    @Test
+    void quarkusServerAndClientSample2() throws IOException {
+        // Both roles in a single run: XxxController (server resource) and
+        // XxxClient (@RegisterRestClient) side by side, sharing the DTOs.
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS)
+                .generate(Role.CONTROLLER, Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void springAllRolesSample2() throws IOException {
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .generate(Role.CONTROLLER, Role.API, Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
     }
 
 

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -44,7 +44,7 @@ class KCodegenTest {
         codegen = new KotlinCodegen(GeneratorParams
                 .rootPackage("com.example")
                 .generateResponseParameter(false)
-                .generateApiInterface(true));
+                .generate(Role.CONTROLLER, Role.API));
         codegen.generate(Path.of("src/test/resources/sample1.yaml"), result);
         // Snapshot only: see generateSample1 — references external types.
         Approvals.verify(getContent(result));

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -195,6 +195,34 @@ class KCodegenTest {
         GeneratedCodeCompiler.assertKotlinCompiles(result);
     }
 
+    @Test
+    void springClientSample2() throws IOException {
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.SPRING).role(Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void quarkusClientSample2() throws IOException {
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS).role(Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void quarkusClientMultipart() throws IOException {
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS).role(Role.CLIENT));
+        codegen.generate(Path.of("src/test/resources/multipart.yaml"), result);
+        // Snapshot only.
+        Approvals.verify(getContent(result));
+    }
+
 
     /**
      * Verifies the generated output against its snapshot and additionally

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -136,6 +136,35 @@ class KCodegenTest {
     }
 
     @Test
+    void quarkusGenerateSample2() throws IOException {
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS));
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void quarkusDoNotGenerateResponseParameter() throws IOException {
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(false)
+                .framework(Framework.QUARKUS));
+        codegen.generate(Path.of("src/test/resources/commonparam.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void quarkusMultipart() throws IOException {
+        codegen = new KotlinCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .framework(Framework.QUARKUS));
+        codegen.generate(Path.of("src/test/resources/multipart.yaml"), result);
+        // Snapshot only: compiling the generated @RestForm parameter would require
+        // the resteasy-reactive artifact, which we deliberately do not depend on.
+        Approvals.verify(getContent(result));
+    }
+
+    @Test
     void inheritedDiscriminatorProperty() throws IOException {
         codegen.generate(Path.of("src/test/resources/matchconfig.yaml"), result);
         verify(result);

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.pasha.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.pasha.approved.txt
@@ -1,0 +1,5512 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.ActivityCursorPage
+import com.example.dto.ActivityItem
+import com.example.dto.Agile
+import com.example.dto.AppearanceSettings
+import com.example.dto.Article
+import com.example.dto.ArticleAttachment
+import com.example.dto.ArticleComment
+import com.example.dto.BackupFile
+import com.example.dto.BackupStatus
+import com.example.dto.BuildBundle
+import com.example.dto.BuildBundleElement
+import com.example.dto.CommandList
+import com.example.dto.CustomField
+import com.example.dto.CustomFieldDefaults
+import com.example.dto.DatabaseBackupSettings
+import com.example.dto.EnumBundle
+import com.example.dto.EnumBundleElement
+import com.example.dto.FieldType
+import com.example.dto.GeneralUserProfile
+import com.example.dto.GlobalSettings
+import com.example.dto.GlobalTimeTrackingSettings
+import com.example.dto.Issue
+import com.example.dto.IssueAttachment
+import com.example.dto.IssueComment
+import com.example.dto.IssueCountResponse
+import com.example.dto.IssueCustomField
+import com.example.dto.IssueLink
+import com.example.dto.IssueLinkType
+import com.example.dto.IssueTag
+import com.example.dto.IssueTimeTracker
+import com.example.dto.IssueWorkItem
+import com.example.dto.License
+import com.example.dto.LocaleSettings
+import com.example.dto.Me
+import com.example.dto.NotificationSettings
+import com.example.dto.NotificationsUserProfile
+import com.example.dto.OwnedBundle
+import com.example.dto.OwnedBundleElement
+import com.example.dto.Project
+import com.example.dto.ProjectCustomField
+import com.example.dto.ProjectTimeTrackingSettings
+import com.example.dto.RestCorsSettings
+import com.example.dto.SavedQuery
+import com.example.dto.SearchSuggestions
+import com.example.dto.Sprint
+import com.example.dto.StateBundle
+import com.example.dto.StateBundleElement
+import com.example.dto.SystemSettings
+import com.example.dto.Telemetry
+import com.example.dto.TimeTrackingUserProfile
+import com.example.dto.User
+import com.example.dto.UserBundle
+import com.example.dto.UserGroup
+import com.example.dto.VcsChange
+import com.example.dto.VersionBundle
+import com.example.dto.VersionBundleElement
+import com.example.dto.WorkItemType
+import com.example.dto.WorkTimeSettings
+import java.time.LocalDate
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.Unit
+import kotlin.collections.List
+import org.springframework.web.bind.`annotation`.DeleteMapping
+import org.springframework.web.bind.`annotation`.GetMapping
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.PostMapping
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestParam
+
+public interface Controller {
+  @GetMapping(
+    value = ["/activities"],
+    produces = ["application/json"],
+  )
+  public fun activitiesGet(
+    @RequestParam(required = false, name = "categories") categories: String?,
+    @RequestParam(required = false, name = "reverse") reverse: Boolean?,
+    @RequestParam(required = false, name = "start") start: String?,
+    @RequestParam(required = false, name = "end") end: String?,
+    @RequestParam(required = false, name = "author") author: String?,
+    @RequestParam(required = false, name = "issueQuery") issueQuery: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<ActivityItem>?
+
+  @GetMapping(
+    value = ["/activities/{id}"],
+    produces = ["application/json"],
+  )
+  public fun activitiesIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required = false,
+      name = "fields") fields: String?): ActivityItem?
+
+  @GetMapping(
+    value = ["/activitiesPage"],
+    produces = ["application/json"],
+  )
+  public fun activitiesPageGet(
+    @RequestParam(required = false, name = "categories") categories: String?,
+    @RequestParam(required = false, name = "reverse") reverse: Boolean?,
+    @RequestParam(required = false, name = "start") start: String?,
+    @RequestParam(required = false, name = "end") end: String?,
+    @RequestParam(required = false, name = "author") author: String?,
+    @RequestParam(required = false, name = "issueQuery") issueQuery: String?,
+    @RequestParam(required = false, name = "cursor") cursor: String?,
+    @RequestParam(required = false, name = "activityId") activityId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ActivityCursorPage?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/build"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<BuildBundle>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/build"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildPost(@RequestBody request: BuildBundle?,
+      @RequestParam(required = false, name = "fields") fields: String?): BuildBundle?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/build/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildIdGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): BuildBundle?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/build/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildIdPost(
+    @RequestBody request: BuildBundle?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): BuildBundle?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/bundles/build/{id}"])
+  public fun adminCustomFieldSettingsBundlesBuildIdDelete(@PathVariable(name = "id") id: String?):
+      Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/build/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildIdValuesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<BuildBundleElement>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/build/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildIdValuesPost(
+    @RequestBody request: BuildBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): BuildBundleElement?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/build/{id}/values/{buildBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildIdValuesBuildBundleElementIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "buildBundleElementId") buildBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): BuildBundleElement?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/build/{id}/values/{buildBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesBuildIdValuesBuildBundleElementIdPost(
+    @RequestBody request: BuildBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "buildBundleElementId") buildBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): BuildBundleElement?
+
+  @DeleteMapping(value =
+      ["/admin/customFieldSettings/bundles/build/{id}/values/{buildBundleElementId}"])
+  public
+      fun adminCustomFieldSettingsBundlesBuildIdValuesBuildBundleElementIdDelete(@PathVariable(name
+      = "id") id: String?, @PathVariable(name = "buildBundleElementId")
+      buildBundleElementId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/enum"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesEnumGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<EnumBundle>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/enum"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesEnumPost(@RequestBody request: EnumBundle?,
+      @RequestParam(required = false, name = "fields") fields: String?): EnumBundle?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/enum/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesEnumIdGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): EnumBundle?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/enum/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesEnumIdPost(
+    @RequestBody request: EnumBundle?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): EnumBundle?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/bundles/enum/{id}"])
+  public fun adminCustomFieldSettingsBundlesEnumIdDelete(@PathVariable(name = "id") id: String?):
+      Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/enum/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesEnumIdValuesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<EnumBundleElement>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/enum/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesEnumIdValuesPost(
+    @RequestBody request: EnumBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): EnumBundleElement?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/enum/{id}/values/{enumBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesEnumIdValuesEnumBundleElementIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "enumBundleElementId") enumBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): EnumBundleElement?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/enum/{id}/values/{enumBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesEnumIdValuesEnumBundleElementIdPost(
+    @RequestBody request: EnumBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "enumBundleElementId") enumBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): EnumBundleElement?
+
+  @DeleteMapping(value =
+      ["/admin/customFieldSettings/bundles/enum/{id}/values/{enumBundleElementId}"])
+  public fun adminCustomFieldSettingsBundlesEnumIdValuesEnumBundleElementIdDelete(@PathVariable(name
+      = "id") id: String?, @PathVariable(name = "enumBundleElementId")
+      enumBundleElementId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/ownedField"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesOwnedFieldGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<OwnedBundle>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/ownedField"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesOwnedFieldPost(@RequestBody request: OwnedBundle?,
+      @RequestParam(required = false, name = "fields") fields: String?): OwnedBundle?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/ownedField/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesOwnedFieldIdGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): OwnedBundle?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/ownedField/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesOwnedFieldIdPost(
+    @RequestBody request: OwnedBundle?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): OwnedBundle?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/bundles/ownedField/{id}"])
+  public fun adminCustomFieldSettingsBundlesOwnedFieldIdDelete(@PathVariable(name = "id")
+      id: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/ownedField/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesOwnedFieldIdValuesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<OwnedBundleElement>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/ownedField/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesOwnedFieldIdValuesPost(
+    @RequestBody request: OwnedBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): OwnedBundleElement?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/ownedField/{id}/values/{ownedBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesOwnedFieldIdValuesOwnedBundleElementIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "ownedBundleElementId") ownedBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): OwnedBundleElement?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/ownedField/{id}/values/{ownedBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesOwnedFieldIdValuesOwnedBundleElementIdPost(
+    @RequestBody request: OwnedBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "ownedBundleElementId") ownedBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): OwnedBundleElement?
+
+  @DeleteMapping(value =
+      ["/admin/customFieldSettings/bundles/ownedField/{id}/values/{ownedBundleElementId}"])
+  public
+      fun adminCustomFieldSettingsBundlesOwnedFieldIdValuesOwnedBundleElementIdDelete(@PathVariable(name
+      = "id") id: String?, @PathVariable(name = "ownedBundleElementId")
+      ownedBundleElementId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/state"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesStateGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<StateBundle>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/state"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesStatePost(@RequestBody request: StateBundle?,
+      @RequestParam(required = false, name = "fields") fields: String?): StateBundle?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/state/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesStateIdGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): StateBundle?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/state/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesStateIdPost(
+    @RequestBody request: StateBundle?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): StateBundle?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/bundles/state/{id}"])
+  public fun adminCustomFieldSettingsBundlesStateIdDelete(@PathVariable(name = "id") id: String?):
+      Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/state/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesStateIdValuesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<StateBundleElement>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/state/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesStateIdValuesPost(
+    @RequestBody request: StateBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): StateBundleElement?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/state/{id}/values/{stateBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesStateIdValuesStateBundleElementIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "stateBundleElementId") stateBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): StateBundleElement?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/state/{id}/values/{stateBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesStateIdValuesStateBundleElementIdPost(
+    @RequestBody request: StateBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "stateBundleElementId") stateBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): StateBundleElement?
+
+  @DeleteMapping(value =
+      ["/admin/customFieldSettings/bundles/state/{id}/values/{stateBundleElementId}"])
+  public
+      fun adminCustomFieldSettingsBundlesStateIdValuesStateBundleElementIdDelete(@PathVariable(name
+      = "id") id: String?, @PathVariable(name = "stateBundleElementId")
+      stateBundleElementId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/user"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<UserBundle>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/user"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserPost(@RequestBody request: UserBundle?,
+      @RequestParam(required = false, name = "fields") fields: String?): UserBundle?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): UserBundle?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdPost(
+    @RequestBody request: UserBundle?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): UserBundle?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/bundles/user/{id}"])
+  public fun adminCustomFieldSettingsBundlesUserIdDelete(@PathVariable(name = "id") id: String?):
+      Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}/aggregatedUsers"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdAggregatedUsersGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<User>?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}/groups"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdGroupsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<UserGroup>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}/groups"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdGroupsPost(
+    @RequestBody request: UserGroup?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): UserGroup?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}/groups/{userGroupId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdGroupsUserGroupIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "userGroupId") userGroupId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): UserGroup?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/bundles/user/{id}/groups/{userGroupId}"])
+  public fun adminCustomFieldSettingsBundlesUserIdGroupsUserGroupIdDelete(@PathVariable(name = "id")
+      id: String?, @PathVariable(name = "userGroupId") userGroupId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}/individuals"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdIndividualsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<User>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}/individuals"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdIndividualsPost(
+    @RequestBody request: User?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): User?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/user/{id}/individuals/{userId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesUserIdIndividualsUserIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "userId") userId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): User?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/bundles/user/{id}/individuals/{userId}"])
+  public fun adminCustomFieldSettingsBundlesUserIdIndividualsUserIdDelete(@PathVariable(name = "id")
+      id: String?, @PathVariable(name = "userId") userId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/version"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesVersionGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<VersionBundle>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/version"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesVersionPost(@RequestBody request: VersionBundle?,
+      @RequestParam(required = false, name = "fields") fields: String?): VersionBundle?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/version/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesVersionIdGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): VersionBundle?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/version/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesVersionIdPost(
+    @RequestBody request: VersionBundle?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): VersionBundle?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/bundles/version/{id}"])
+  public fun adminCustomFieldSettingsBundlesVersionIdDelete(@PathVariable(name = "id") id: String?):
+      Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/version/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesVersionIdValuesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<VersionBundleElement>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/version/{id}/values"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesVersionIdValuesPost(
+    @RequestBody request: VersionBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): VersionBundleElement?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/bundles/version/{id}/values/{versionBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesVersionIdValuesVersionBundleElementIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "versionBundleElementId") versionBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): VersionBundleElement?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/bundles/version/{id}/values/{versionBundleElementId}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsBundlesVersionIdValuesVersionBundleElementIdPost(
+    @RequestBody request: VersionBundleElement?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "versionBundleElementId") versionBundleElementId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): VersionBundleElement?
+
+  @DeleteMapping(value =
+      ["/admin/customFieldSettings/bundles/version/{id}/values/{versionBundleElementId}"])
+  public
+      fun adminCustomFieldSettingsBundlesVersionIdValuesVersionBundleElementIdDelete(@PathVariable(name
+      = "id") id: String?, @PathVariable(name = "versionBundleElementId")
+      versionBundleElementId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/customFields"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsCustomFieldsGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<CustomField>?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/customFields"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsCustomFieldsPost(@RequestBody request: CustomField?,
+      @RequestParam(required = false, name = "fields") fields: String?): CustomField?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/customFields/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsCustomFieldsIdGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): CustomField?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/customFields/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsCustomFieldsIdPost(
+    @RequestBody request: CustomField?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): CustomField?
+
+  @DeleteMapping(value = ["/admin/customFieldSettings/customFields/{id}"])
+  public fun adminCustomFieldSettingsCustomFieldsIdDelete(@PathVariable(name = "id") id: String?):
+      Unit
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/customFields/{id}/fieldDefaults"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsCustomFieldsIdFieldDefaultsGet(@PathVariable(name = "id")
+      id: String?, @RequestParam(required = false, name = "fields") fields: String?):
+      CustomFieldDefaults?
+
+  @PostMapping(
+    value = ["/admin/customFieldSettings/customFields/{id}/fieldDefaults"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsCustomFieldsIdFieldDefaultsPost(
+    @RequestBody request: CustomFieldDefaults?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): CustomFieldDefaults?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/customFields/{id}/instances"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsCustomFieldsIdInstancesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<ProjectCustomField>?
+
+  @GetMapping(
+    value = ["/admin/customFieldSettings/types"],
+    produces = ["application/json"],
+  )
+  public fun adminCustomFieldSettingsTypesGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<FieldType>?
+
+  @GetMapping(
+    value = ["/admin/databaseBackup/backups"],
+    produces = ["application/json"],
+  )
+  public fun adminDatabaseBackupBackupsGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<BackupFile>?
+
+  @GetMapping(
+    value = ["/admin/databaseBackup/backups/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminDatabaseBackupBackupsIdGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): BackupFile?
+
+  @GetMapping(
+    value = ["/admin/databaseBackup/settings"],
+    produces = ["application/json"],
+  )
+  public fun adminDatabaseBackupSettingsGet(@RequestParam(required = false, name = "fields")
+      fields: String?): DatabaseBackupSettings?
+
+  @PostMapping(
+    value = ["/admin/databaseBackup/settings"],
+    produces = ["application/json"],
+  )
+  public fun adminDatabaseBackupSettingsPost(@RequestBody request: DatabaseBackupSettings?,
+      @RequestParam(required = false, name = "fields") fields: String?): DatabaseBackupSettings?
+
+  @GetMapping(
+    value = ["/admin/databaseBackup/settings/backupStatus"],
+    produces = ["application/json"],
+  )
+  public fun adminDatabaseBackupSettingsBackupStatusGet(@RequestParam(required = false, name =
+      "fields") fields: String?): BackupStatus?
+
+  @GetMapping(
+    value = ["/admin/globalSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsGet(@RequestParam(required = false, name = "fields")
+      fields: String?): GlobalSettings?
+
+  @PostMapping(
+    value = ["/admin/globalSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsPost(@RequestBody request: GlobalSettings?, @RequestParam(required =
+      false, name = "fields") fields: String?): GlobalSettings?
+
+  @GetMapping(
+    value = ["/admin/globalSettings/appearanceSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsAppearanceSettingsGet(@RequestParam(required = false, name =
+      "fields") fields: String?): AppearanceSettings?
+
+  @PostMapping(
+    value = ["/admin/globalSettings/appearanceSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsAppearanceSettingsPost(@RequestBody request: AppearanceSettings?,
+      @RequestParam(required = false, name = "fields") fields: String?): AppearanceSettings?
+
+  @GetMapping(
+    value = ["/admin/globalSettings/license"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsLicenseGet(@RequestParam(required = false, name = "fields")
+      fields: String?): License?
+
+  @PostMapping(
+    value = ["/admin/globalSettings/license"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsLicensePost(@RequestBody request: License?, @RequestParam(required =
+      false, name = "fields") fields: String?): License?
+
+  @GetMapping(
+    value = ["/admin/globalSettings/localeSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsLocaleSettingsGet(@RequestParam(required = false, name = "fields")
+      fields: String?): LocaleSettings?
+
+  @PostMapping(
+    value = ["/admin/globalSettings/localeSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsLocaleSettingsPost(@RequestBody request: LocaleSettings?,
+      @RequestParam(required = false, name = "fields") fields: String?): LocaleSettings?
+
+  @GetMapping(
+    value = ["/admin/globalSettings/notificationSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsNotificationSettingsGet(@RequestParam(required = false, name =
+      "fields") fields: String?): NotificationSettings?
+
+  @PostMapping(
+    value = ["/admin/globalSettings/notificationSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsNotificationSettingsPost(@RequestBody
+      request: NotificationSettings?, @RequestParam(required = false, name = "fields")
+      fields: String?): NotificationSettings?
+
+  @GetMapping(
+    value = ["/admin/globalSettings/restSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsRestSettingsGet(@RequestParam(required = false, name = "fields")
+      fields: String?): RestCorsSettings?
+
+  @PostMapping(
+    value = ["/admin/globalSettings/restSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsRestSettingsPost(@RequestBody request: RestCorsSettings?,
+      @RequestParam(required = false, name = "fields") fields: String?): RestCorsSettings?
+
+  @GetMapping(
+    value = ["/admin/globalSettings/systemSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsSystemSettingsGet(@RequestParam(required = false, name = "fields")
+      fields: String?): SystemSettings?
+
+  @PostMapping(
+    value = ["/admin/globalSettings/systemSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminGlobalSettingsSystemSettingsPost(@RequestBody request: SystemSettings?,
+      @RequestParam(required = false, name = "fields") fields: String?): SystemSettings?
+
+  @GetMapping(
+    value = ["/admin/projects"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Project>?
+
+  @PostMapping(
+    value = ["/admin/projects"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsPost(
+    @RequestBody request: Project?,
+    @RequestParam(required = false, name = "template") template: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Project?
+
+  @GetMapping(
+    value = ["/admin/projects/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required =
+      false, name = "fields") fields: String?): Project?
+
+  @PostMapping(
+    value = ["/admin/projects/{id}"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdPost(
+    @RequestBody request: Project?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Project?
+
+  @DeleteMapping(value = ["/admin/projects/{id}"])
+  public fun adminProjectsIdDelete(@PathVariable(name = "id") id: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/projects/{id}/customFields"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdCustomFieldsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<ProjectCustomField>?
+
+  @PostMapping(
+    value = ["/admin/projects/{id}/customFields"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdCustomFieldsPost(
+    @RequestBody request: ProjectCustomField?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ProjectCustomField?
+
+  @GetMapping(
+    value = ["/admin/projects/{id}/customFields/{projectCustomFieldId}"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdCustomFieldsProjectCustomFieldIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "projectCustomFieldId") projectCustomFieldId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ProjectCustomField?
+
+  @PostMapping(
+    value = ["/admin/projects/{id}/customFields/{projectCustomFieldId}"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdCustomFieldsProjectCustomFieldIdPost(
+    @RequestBody request: ProjectCustomField?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "projectCustomFieldId") projectCustomFieldId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ProjectCustomField?
+
+  @DeleteMapping(value = ["/admin/projects/{id}/customFields/{projectCustomFieldId}"])
+  public fun adminProjectsIdCustomFieldsProjectCustomFieldIdDelete(@PathVariable(name = "id")
+      id: String?, @PathVariable(name = "projectCustomFieldId") projectCustomFieldId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/projects/{id}/issues"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdIssuesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "customFields") customFields: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Issue>?
+
+  @PostMapping(
+    value = ["/admin/projects/{id}/issues"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdIssuesPost(
+    @RequestBody request: Issue?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Issue?
+
+  @GetMapping(
+    value = ["/admin/projects/{id}/issues/{issueId}"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdIssuesIssueIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueId") issueId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Issue?
+
+  @PostMapping(
+    value = ["/admin/projects/{id}/issues/{issueId}"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdIssuesIssueIdPost(
+    @RequestBody request: Issue?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueId") issueId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Issue?
+
+  @DeleteMapping(value = ["/admin/projects/{id}/issues/{issueId}"])
+  public fun adminProjectsIdIssuesIssueIdDelete(@PathVariable(name = "id") id: String?,
+      @PathVariable(name = "issueId") issueId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/projects/{id}/timeTrackingSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdTimeTrackingSettingsGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?):
+      ProjectTimeTrackingSettings?
+
+  @PostMapping(
+    value = ["/admin/projects/{id}/timeTrackingSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdTimeTrackingSettingsPost(
+    @RequestBody request: ProjectTimeTrackingSettings?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ProjectTimeTrackingSettings?
+
+  @GetMapping(
+    value = ["/admin/projects/{id}/timeTrackingSettings/workItemTypes"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdTimeTrackingSettingsWorkItemTypesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<WorkItemType>?
+
+  @PostMapping(
+    value = ["/admin/projects/{id}/timeTrackingSettings/workItemTypes"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdTimeTrackingSettingsWorkItemTypesPost(
+    @RequestBody request: WorkItemType?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): WorkItemType?
+
+  @GetMapping(
+    value = ["/admin/projects/{id}/timeTrackingSettings/workItemTypes/{workItemTypeId}"],
+    produces = ["application/json"],
+  )
+  public fun adminProjectsIdTimeTrackingSettingsWorkItemTypesWorkItemTypeIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "workItemTypeId") workItemTypeId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): WorkItemType?
+
+  @DeleteMapping(value =
+      ["/admin/projects/{id}/timeTrackingSettings/workItemTypes/{workItemTypeId}"])
+  public fun adminProjectsIdTimeTrackingSettingsWorkItemTypesWorkItemTypeIdDelete(@PathVariable(name
+      = "id") id: String?, @PathVariable(name = "workItemTypeId") workItemTypeId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/telemetry"],
+    produces = ["application/json"],
+  )
+  public fun adminTelemetryGet(@RequestParam(required = false, name = "fields") fields: String?):
+      Telemetry?
+
+  @GetMapping(
+    value = ["/admin/timeTrackingSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminTimeTrackingSettingsGet(@RequestParam(required = false, name = "fields")
+      fields: String?): GlobalTimeTrackingSettings?
+
+  @GetMapping(
+    value = ["/admin/timeTrackingSettings/workItemTypes"],
+    produces = ["application/json"],
+  )
+  public fun adminTimeTrackingSettingsWorkItemTypesGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<WorkItemType>?
+
+  @PostMapping(
+    value = ["/admin/timeTrackingSettings/workItemTypes"],
+    produces = ["application/json"],
+  )
+  public fun adminTimeTrackingSettingsWorkItemTypesPost(@RequestBody request: WorkItemType?,
+      @RequestParam(required = false, name = "fields") fields: String?): WorkItemType?
+
+  @GetMapping(
+    value = ["/admin/timeTrackingSettings/workItemTypes/{workItemTypeId}"],
+    produces = ["application/json"],
+  )
+  public fun adminTimeTrackingSettingsWorkItemTypesWorkItemTypeIdGet(@PathVariable(name =
+      "workItemTypeId") workItemTypeId: String?, @RequestParam(required = false, name = "fields")
+      fields: String?): WorkItemType?
+
+  @PostMapping(
+    value = ["/admin/timeTrackingSettings/workItemTypes/{workItemTypeId}"],
+    produces = ["application/json"],
+  )
+  public fun adminTimeTrackingSettingsWorkItemTypesWorkItemTypeIdPost(
+    @RequestBody request: WorkItemType?,
+    @PathVariable(name = "workItemTypeId") workItemTypeId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): WorkItemType?
+
+  @DeleteMapping(value = ["/admin/timeTrackingSettings/workItemTypes/{workItemTypeId}"])
+  public fun adminTimeTrackingSettingsWorkItemTypesWorkItemTypeIdDelete(@PathVariable(name =
+      "workItemTypeId") workItemTypeId: String?): Unit
+
+  @GetMapping(
+    value = ["/admin/timeTrackingSettings/workTimeSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminTimeTrackingSettingsWorkTimeSettingsGet(@RequestParam(required = false, name =
+      "fields") fields: String?): WorkTimeSettings?
+
+  @PostMapping(
+    value = ["/admin/timeTrackingSettings/workTimeSettings"],
+    produces = ["application/json"],
+  )
+  public fun adminTimeTrackingSettingsWorkTimeSettingsPost(@RequestBody request: WorkTimeSettings?,
+      @RequestParam(required = false, name = "fields") fields: String?): WorkTimeSettings?
+
+  @GetMapping(
+    value = ["/agiles"],
+    produces = ["application/json"],
+  )
+  public fun agilesGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Agile>?
+
+  @PostMapping(
+    value = ["/agiles"],
+    produces = ["application/json"],
+  )
+  public fun agilesPost(
+    @RequestBody request: Agile?,
+    @RequestParam(required = false, name = "template") template: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Agile?
+
+  @GetMapping(
+    value = ["/agiles/{id}"],
+    produces = ["application/json"],
+  )
+  public fun agilesIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required = false,
+      name = "fields") fields: String?): Agile?
+
+  @PostMapping(
+    value = ["/agiles/{id}"],
+    produces = ["application/json"],
+  )
+  public fun agilesIdPost(
+    @RequestBody request: Agile?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Agile?
+
+  @DeleteMapping(value = ["/agiles/{id}"])
+  public fun agilesIdDelete(@PathVariable(name = "id") id: String?): Unit
+
+  @GetMapping(
+    value = ["/agiles/{id}/sprints"],
+    produces = ["application/json"],
+  )
+  public fun agilesIdSprintsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Sprint>?
+
+  @PostMapping(
+    value = ["/agiles/{id}/sprints"],
+    produces = ["application/json"],
+  )
+  public fun agilesIdSprintsPost(
+    @RequestBody request: Sprint?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Sprint?
+
+  @GetMapping(
+    value = ["/agiles/{id}/sprints/{sprintId}"],
+    produces = ["application/json"],
+  )
+  public fun agilesIdSprintsSprintIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "sprintId") sprintId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Sprint?
+
+  @PostMapping(
+    value = ["/agiles/{id}/sprints/{sprintId}"],
+    produces = ["application/json"],
+  )
+  public fun agilesIdSprintsSprintIdPost(
+    @RequestBody request: Sprint?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "sprintId") sprintId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Sprint?
+
+  @DeleteMapping(value = ["/agiles/{id}/sprints/{sprintId}"])
+  public fun agilesIdSprintsSprintIdDelete(@PathVariable(name = "id") id: String?,
+      @PathVariable(name = "sprintId") sprintId: String?): Unit
+
+  @GetMapping(
+    value = ["/articles"],
+    produces = ["application/json"],
+  )
+  public fun articlesGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Article>?
+
+  @PostMapping(
+    value = ["/articles"],
+    produces = ["application/json"],
+  )
+  public fun articlesPost(
+    @RequestBody request: Article?,
+    @RequestParam(required = false, name = "draftId") draftId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Article?
+
+  @GetMapping(
+    value = ["/articles/{id}"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required = false,
+      name = "fields") fields: String?): Article?
+
+  @PostMapping(
+    value = ["/articles/{id}"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdPost(
+    @RequestBody request: Article?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Article?
+
+  @DeleteMapping(value = ["/articles/{id}"])
+  public fun articlesIdDelete(@PathVariable(name = "id") id: String?): Unit
+
+  @GetMapping(
+    value = ["/articles/{id}/attachments"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdAttachmentsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<ArticleAttachment>?
+
+  @PostMapping(
+    value = ["/articles/{id}/attachments"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdAttachmentsPost(
+    @RequestBody request: ArticleAttachment?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ArticleAttachment?
+
+  @GetMapping(
+    value = ["/articles/{id}/attachments/{articleAttachmentId}"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdAttachmentsArticleAttachmentIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "articleAttachmentId") articleAttachmentId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ArticleAttachment?
+
+  @PostMapping(
+    value = ["/articles/{id}/attachments/{articleAttachmentId}"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdAttachmentsArticleAttachmentIdPost(
+    @RequestBody request: ArticleAttachment?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "articleAttachmentId") articleAttachmentId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ArticleAttachment?
+
+  @DeleteMapping(value = ["/articles/{id}/attachments/{articleAttachmentId}"])
+  public fun articlesIdAttachmentsArticleAttachmentIdDelete(@PathVariable(name = "id") id: String?,
+      @PathVariable(name = "articleAttachmentId") articleAttachmentId: String?): Unit
+
+  @GetMapping(
+    value = ["/articles/{id}/childArticles"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdChildArticlesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Article>?
+
+  @PostMapping(
+    value = ["/articles/{id}/childArticles"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdChildArticlesPost(
+    @RequestBody request: Article?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Article?
+
+  @GetMapping(
+    value = ["/articles/{id}/childArticles/{articleId}"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdChildArticlesArticleIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "articleId") articleId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Article?
+
+  @PostMapping(
+    value = ["/articles/{id}/childArticles/{articleId}"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdChildArticlesArticleIdPost(
+    @RequestBody request: Article?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "articleId") articleId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Article?
+
+  @DeleteMapping(value = ["/articles/{id}/childArticles/{articleId}"])
+  public fun articlesIdChildArticlesArticleIdDelete(@PathVariable(name = "id") id: String?,
+      @PathVariable(name = "articleId") articleId: String?): Unit
+
+  @GetMapping(
+    value = ["/articles/{id}/comments"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdCommentsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<ArticleComment>?
+
+  @PostMapping(
+    value = ["/articles/{id}/comments"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdCommentsPost(
+    @RequestBody request: ArticleComment?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "draftId") draftId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ArticleComment?
+
+  @GetMapping(
+    value = ["/articles/{id}/comments/{articleCommentId}"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdCommentsArticleCommentIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "articleCommentId") articleCommentId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ArticleComment?
+
+  @PostMapping(
+    value = ["/articles/{id}/comments/{articleCommentId}"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdCommentsArticleCommentIdPost(
+    @RequestBody request: ArticleComment?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "articleCommentId") articleCommentId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ArticleComment?
+
+  @DeleteMapping(value = ["/articles/{id}/comments/{articleCommentId}"])
+  public fun articlesIdCommentsArticleCommentIdDelete(@PathVariable(name = "id") id: String?,
+      @PathVariable(name = "articleCommentId") articleCommentId: String?): Unit
+
+  @GetMapping(
+    value = ["/articles/{id}/parentArticle"],
+    produces = ["application/json"],
+  )
+  public fun articlesIdParentArticleGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): Article?
+
+  @PostMapping(
+    value = ["/commands"],
+    produces = ["application/json"],
+  )
+  public fun commandsPost(
+    @RequestBody request: CommandList?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): CommandList?
+
+  @PostMapping(
+    value = ["/commands/assist"],
+    produces = ["application/json"],
+  )
+  public fun commandsAssistPost(@RequestBody request: CommandList?, @RequestParam(required = false,
+      name = "fields") fields: String?): CommandList?
+
+  @GetMapping(
+    value = ["/groups"],
+    produces = ["application/json"],
+  )
+  public fun groupsGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<UserGroup>?
+
+  @GetMapping(
+    value = ["/groups/{id}"],
+    produces = ["application/json"],
+  )
+  public fun groupsIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required = false,
+      name = "fields") fields: String?): UserGroup?
+
+  @GetMapping(
+    value = ["/issueLinkTypes"],
+    produces = ["application/json"],
+  )
+  public fun issueLinkTypesGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueLinkType>?
+
+  @PostMapping(
+    value = ["/issueLinkTypes"],
+    produces = ["application/json"],
+  )
+  public fun issueLinkTypesPost(@RequestBody request: IssueLinkType?, @RequestParam(required =
+      false, name = "fields") fields: String?): IssueLinkType?
+
+  @GetMapping(
+    value = ["/issueLinkTypes/{id}"],
+    produces = ["application/json"],
+  )
+  public fun issueLinkTypesIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required =
+      false, name = "fields") fields: String?): IssueLinkType?
+
+  @PostMapping(
+    value = ["/issueLinkTypes/{id}"],
+    produces = ["application/json"],
+  )
+  public fun issueLinkTypesIdPost(
+    @RequestBody request: IssueLinkType?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueLinkType?
+
+  @DeleteMapping(value = ["/issueLinkTypes/{id}"])
+  public fun issueLinkTypesIdDelete(@PathVariable(name = "id") id: String?): Unit
+
+  @GetMapping(
+    value = ["/issueTags"],
+    produces = ["application/json"],
+  )
+  public fun issueTagsGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueTag>?
+
+  @PostMapping(
+    value = ["/issueTags"],
+    produces = ["application/json"],
+  )
+  public fun issueTagsPost(@RequestBody request: IssueTag?, @RequestParam(required = false, name =
+      "fields") fields: String?): IssueTag?
+
+  @GetMapping(
+    value = ["/issueTags/{id}"],
+    produces = ["application/json"],
+  )
+  public fun issueTagsIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required = false,
+      name = "fields") fields: String?): IssueTag?
+
+  @PostMapping(
+    value = ["/issueTags/{id}"],
+    produces = ["application/json"],
+  )
+  public fun issueTagsIdPost(
+    @RequestBody request: IssueTag?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueTag?
+
+  @DeleteMapping(value = ["/issueTags/{id}"])
+  public fun issueTagsIdDelete(@PathVariable(name = "id") id: String?): Unit
+
+  @GetMapping(
+    value = ["/issueTags/{id}/issues"],
+    produces = ["application/json"],
+  )
+  public fun issueTagsIdIssuesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "customFields") customFields: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Issue>?
+
+  @GetMapping(
+    value = ["/issues"],
+    produces = ["application/json"],
+  )
+  public fun issuesGet(
+    @RequestParam(required = false, name = "query") query: String?,
+    @RequestParam(required = false, name = "customFields") customFields: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Issue>?
+
+  @PostMapping(
+    value = ["/issues"],
+    produces = ["application/json"],
+  )
+  public fun issuesPost(
+    @RequestBody request: Issue?,
+    @RequestParam(required = false, name = "draftId") draftId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Issue?
+
+  @GetMapping(
+    value = ["/issues/{id}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required = false,
+      name = "fields") fields: String?): Issue?
+
+  @PostMapping(
+    value = ["/issues/{id}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdPost(
+    @RequestBody request: Issue?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Issue?
+
+  @DeleteMapping(value = ["/issues/{id}"])
+  public fun issuesIdDelete(@PathVariable(name = "id") id: String?): Unit
+
+  @GetMapping(
+    value = ["/issues/{id}/activities"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdActivitiesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "categories") categories: String?,
+    @RequestParam(required = false, name = "reverse") reverse: Boolean?,
+    @RequestParam(required = false, name = "start") start: String?,
+    @RequestParam(required = false, name = "end") end: String?,
+    @RequestParam(required = false, name = "author") author: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<ActivityItem>?
+
+  @GetMapping(
+    value = ["/issues/{id}/activities/{activityItemId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdActivitiesActivityItemIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "activityItemId") activityItemId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ActivityItem?
+
+  @GetMapping(
+    value = ["/issues/{id}/activitiesPage"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdActivitiesPageGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "categories") categories: String?,
+    @RequestParam(required = false, name = "reverse") reverse: Boolean?,
+    @RequestParam(required = false, name = "start") start: String?,
+    @RequestParam(required = false, name = "end") end: String?,
+    @RequestParam(required = false, name = "author") author: String?,
+    @RequestParam(required = false, name = "cursor") cursor: String?,
+    @RequestParam(required = false, name = "activityId") activityId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): ActivityCursorPage?
+
+  @GetMapping(
+    value = ["/issues/{id}/attachments"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdAttachmentsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueAttachment>?
+
+  @PostMapping(
+    value = ["/issues/{id}/attachments"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdAttachmentsPost(
+    @RequestBody request: IssueAttachment?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueAttachment?
+
+  @GetMapping(
+    value = ["/issues/{id}/attachments/{issueAttachmentId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdAttachmentsIssueAttachmentIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueAttachmentId") issueAttachmentId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueAttachment?
+
+  @PostMapping(
+    value = ["/issues/{id}/attachments/{issueAttachmentId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdAttachmentsIssueAttachmentIdPost(
+    @RequestBody request: IssueAttachment?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueAttachmentId") issueAttachmentId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueAttachment?
+
+  @DeleteMapping(value = ["/issues/{id}/attachments/{issueAttachmentId}"])
+  public fun issuesIdAttachmentsIssueAttachmentIdDelete(@PathVariable(name = "id") id: String?,
+      @PathVariable(name = "issueAttachmentId") issueAttachmentId: String?): Unit
+
+  @GetMapping(
+    value = ["/issues/{id}/comments"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdCommentsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueComment>?
+
+  @PostMapping(
+    value = ["/issues/{id}/comments"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdCommentsPost(
+    @RequestBody request: IssueComment?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "draftId") draftId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueComment?
+
+  @GetMapping(
+    value = ["/issues/{id}/comments/{issueCommentId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdCommentsIssueCommentIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueCommentId") issueCommentId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueComment?
+
+  @PostMapping(
+    value = ["/issues/{id}/comments/{issueCommentId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdCommentsIssueCommentIdPost(
+    @RequestBody request: IssueComment?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueCommentId") issueCommentId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueComment?
+
+  @DeleteMapping(value = ["/issues/{id}/comments/{issueCommentId}"])
+  public fun issuesIdCommentsIssueCommentIdDelete(@PathVariable(name = "id") id: String?,
+      @PathVariable(name = "issueCommentId") issueCommentId: String?): Unit
+
+  @GetMapping(
+    value = ["/issues/{id}/customFields"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdCustomFieldsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueCustomField>?
+
+  @GetMapping(
+    value = ["/issues/{id}/customFields/{issueCustomFieldId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdCustomFieldsIssueCustomFieldIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueCustomFieldId") issueCustomFieldId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueCustomField?
+
+  @PostMapping(
+    value = ["/issues/{id}/customFields/{issueCustomFieldId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdCustomFieldsIssueCustomFieldIdPost(
+    @RequestBody request: IssueCustomField?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueCustomFieldId") issueCustomFieldId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueCustomField?
+
+  @GetMapping(
+    value = ["/issues/{id}/links"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdLinksGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueLink>?
+
+  @GetMapping(
+    value = ["/issues/{id}/links/{issueLinkId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdLinksIssueLinkIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueLinkId") issueLinkId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueLink?
+
+  @GetMapping(
+    value = ["/issues/{id}/links/{issueLinkId}/issues"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdLinksIssueLinkIdIssuesGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueLinkId") issueLinkId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Issue>?
+
+  @PostMapping(
+    value = ["/issues/{id}/links/{issueLinkId}/issues"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdLinksIssueLinkIdIssuesPost(
+    @RequestBody request: Issue?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueLinkId") issueLinkId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Issue?
+
+  @DeleteMapping(value = ["/issues/{id}/links/{issueLinkId}/issues/{issueId}"])
+  public fun issuesIdLinksIssueLinkIdIssuesIssueIdDelete(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueLinkId") issueLinkId: String?,
+    @PathVariable(name = "issueId") issueId: String?,
+  ): Unit
+
+  @GetMapping(
+    value = ["/issues/{id}/project"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdProjectGet(@PathVariable(name = "id") id: String?, @RequestParam(required =
+      false, name = "fields") fields: String?): Project?
+
+  @PostMapping(
+    value = ["/issues/{id}/project"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdProjectPost(
+    @RequestBody request: Project?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): Project?
+
+  @GetMapping(
+    value = ["/issues/{id}/sprints"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdSprintsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<Sprint>?
+
+  @GetMapping(
+    value = ["/issues/{id}/tags"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdTagsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueTag>?
+
+  @PostMapping(
+    value = ["/issues/{id}/tags"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdTagsPost(
+    @RequestBody request: IssueTag?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueTag?
+
+  @GetMapping(
+    value = ["/issues/{id}/tags/{issueTagId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdTagsIssueTagIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueTagId") issueTagId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueTag?
+
+  @DeleteMapping(value = ["/issues/{id}/tags/{issueTagId}"])
+  public fun issuesIdTagsIssueTagIdDelete(@PathVariable(name = "id") id: String?, @PathVariable(name
+      = "issueTagId") issueTagId: String?): Unit
+
+  @GetMapping(
+    value = ["/issues/{id}/timeTracking"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdTimeTrackingGet(@PathVariable(name = "id") id: String?, @RequestParam(required
+      = false, name = "fields") fields: String?): IssueTimeTracker?
+
+  @GetMapping(
+    value = ["/issues/{id}/timeTracking/workItems"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdTimeTrackingWorkItemsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueWorkItem>?
+
+  @PostMapping(
+    value = ["/issues/{id}/timeTracking/workItems"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdTimeTrackingWorkItemsPost(
+    @RequestBody request: IssueWorkItem?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueWorkItem?
+
+  @GetMapping(
+    value = ["/issues/{id}/timeTracking/workItems/{issueWorkItemId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdTimeTrackingWorkItemsIssueWorkItemIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueWorkItemId") issueWorkItemId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueWorkItem?
+
+  @PostMapping(
+    value = ["/issues/{id}/timeTracking/workItems/{issueWorkItemId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdTimeTrackingWorkItemsIssueWorkItemIdPost(
+    @RequestBody request: IssueWorkItem?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "issueWorkItemId") issueWorkItemId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): IssueWorkItem?
+
+  @DeleteMapping(value = ["/issues/{id}/timeTracking/workItems/{issueWorkItemId}"])
+  public fun issuesIdTimeTrackingWorkItemsIssueWorkItemIdDelete(@PathVariable(name = "id")
+      id: String?, @PathVariable(name = "issueWorkItemId") issueWorkItemId: String?): Unit
+
+  @GetMapping(
+    value = ["/issues/{id}/vcsChanges"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdVcsChangesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<VcsChange>?
+
+  @PostMapping(
+    value = ["/issues/{id}/vcsChanges"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdVcsChangesPost(
+    @RequestBody request: VcsChange?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): VcsChange?
+
+  @GetMapping(
+    value = ["/issues/{id}/vcsChanges/{vcsChangeId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdVcsChangesVcsChangeIdGet(
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "vcsChangeId") vcsChangeId: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): VcsChange?
+
+  @PostMapping(
+    value = ["/issues/{id}/vcsChanges/{vcsChangeId}"],
+    produces = ["application/json"],
+  )
+  public fun issuesIdVcsChangesVcsChangeIdPost(
+    @RequestBody request: VcsChange?,
+    @PathVariable(name = "id") id: String?,
+    @PathVariable(name = "vcsChangeId") vcsChangeId: String?,
+    @RequestParam(required = false, name = "muteUpdateNotifications")
+        muteUpdateNotifications: Boolean?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): VcsChange?
+
+  @DeleteMapping(value = ["/issues/{id}/vcsChanges/{vcsChangeId}"])
+  public fun issuesIdVcsChangesVcsChangeIdDelete(@PathVariable(name = "id") id: String?,
+      @PathVariable(name = "vcsChangeId") vcsChangeId: String?): Unit
+
+  @PostMapping(
+    value = ["/issuesGetter/count"],
+    produces = ["application/json"],
+  )
+  public fun issuesGetterCountPost(@RequestBody request: IssueCountResponse?, @RequestParam(required
+      = false, name = "fields") fields: String?): IssueCountResponse?
+
+  @GetMapping(
+    value = ["/savedQueries"],
+    produces = ["application/json"],
+  )
+  public fun savedQueriesGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<SavedQuery>?
+
+  @PostMapping(
+    value = ["/savedQueries"],
+    produces = ["application/json"],
+  )
+  public fun savedQueriesPost(@RequestBody request: SavedQuery?, @RequestParam(required = false,
+      name = "fields") fields: String?): SavedQuery?
+
+  @GetMapping(
+    value = ["/savedQueries/{id}"],
+    produces = ["application/json"],
+  )
+  public fun savedQueriesIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required =
+      false, name = "fields") fields: String?): SavedQuery?
+
+  @PostMapping(
+    value = ["/savedQueries/{id}"],
+    produces = ["application/json"],
+  )
+  public fun savedQueriesIdPost(
+    @RequestBody request: SavedQuery?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): SavedQuery?
+
+  @DeleteMapping(value = ["/savedQueries/{id}"])
+  public fun savedQueriesIdDelete(@PathVariable(name = "id") id: String?): Unit
+
+  @PostMapping(
+    value = ["/search/assist"],
+    produces = ["application/json"],
+  )
+  public fun searchAssistPost(@RequestBody request: SearchSuggestions?, @RequestParam(required =
+      false, name = "fields") fields: String?): SearchSuggestions?
+
+  @GetMapping(
+    value = ["/users"],
+    produces = ["application/json"],
+  )
+  public fun usersGet(
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<User>?
+
+  @GetMapping(
+    value = ["/users/{id}"],
+    produces = ["application/json"],
+  )
+  public fun usersIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required = false, name
+      = "fields") fields: String?): User?
+
+  @GetMapping(
+    value = ["/users/{id}/profiles/general"],
+    produces = ["application/json"],
+  )
+  public fun usersIdProfilesGeneralGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): GeneralUserProfile?
+
+  @PostMapping(
+    value = ["/users/{id}/profiles/general"],
+    produces = ["application/json"],
+  )
+  public fun usersIdProfilesGeneralPost(
+    @RequestBody request: GeneralUserProfile?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): GeneralUserProfile?
+
+  @GetMapping(
+    value = ["/users/{id}/profiles/notifications"],
+    produces = ["application/json"],
+  )
+  public fun usersIdProfilesNotificationsGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): NotificationsUserProfile?
+
+  @PostMapping(
+    value = ["/users/{id}/profiles/notifications"],
+    produces = ["application/json"],
+  )
+  public fun usersIdProfilesNotificationsPost(
+    @RequestBody request: NotificationsUserProfile?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): NotificationsUserProfile?
+
+  @GetMapping(
+    value = ["/users/{id}/profiles/timetracking"],
+    produces = ["application/json"],
+  )
+  public fun usersIdProfilesTimetrackingGet(@PathVariable(name = "id") id: String?,
+      @RequestParam(required = false, name = "fields") fields: String?): TimeTrackingUserProfile?
+
+  @PostMapping(
+    value = ["/users/{id}/profiles/timetracking"],
+    produces = ["application/json"],
+  )
+  public fun usersIdProfilesTimetrackingPost(
+    @RequestBody request: TimeTrackingUserProfile?,
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+  ): TimeTrackingUserProfile?
+
+  @GetMapping(
+    value = ["/users/{id}/savedQueries"],
+    produces = ["application/json"],
+  )
+  public fun usersIdSavedQueriesGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<SavedQuery>?
+
+  @GetMapping(
+    value = ["/users/{id}/tags"],
+    produces = ["application/json"],
+  )
+  public fun usersIdTagsGet(
+    @PathVariable(name = "id") id: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueTag>?
+
+  @GetMapping(
+    value = ["/users/me"],
+    produces = ["application/json"],
+  )
+  public fun usersMeGet(@RequestParam(required = false, name = "fields") fields: String?): Me?
+
+  @GetMapping(
+    value = ["/workItems"],
+    produces = ["application/json"],
+  )
+  public fun workItemsGet(
+    @RequestParam(required = false, name = "query") query: String?,
+    @RequestParam(required = false, name = "startDate") startDate: LocalDate?,
+    @RequestParam(required = false, name = "endDate") endDate: LocalDate?,
+    @RequestParam(required = false, name = "start") start: Int?,
+    @RequestParam(required = false, name = "end") end: Int?,
+    @RequestParam(required = false, name = "createdStart") createdStart: Int?,
+    @RequestParam(required = false, name = "createdEnd") createdEnd: Int?,
+    @RequestParam(required = false, name = "updatedStart") updatedStart: Int?,
+    @RequestParam(required = false, name = "updatedEnd") updatedEnd: Int?,
+    @RequestParam(required = false, name = "author") author: String?,
+    @RequestParam(required = false, name = "creator") creator: String?,
+    @RequestParam(required = false, name = "fields") fields: String?,
+    @RequestParam(required = false, name = "${'$'}skip") `$skip`: Int?,
+    @RequestParam(required = false, name = "${'$'}top") `$top`: Int?,
+  ): List<IssueWorkItem>?
+
+  @GetMapping(
+    value = ["/workItems/{id}"],
+    produces = ["application/json"],
+  )
+  public fun workItemsIdGet(@PathVariable(name = "id") id: String?, @RequestParam(required = false,
+      name = "fields") fields: String?): IssueWorkItem?
+}
+---
+/com/example/dto
+---
+/com/example/dto/ActivityCategory.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ActivityCategory(
+  public val id: String? = null,
+)
+---
+/com/example/dto/ActivityCursorPage.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ActivityCursorPage(
+  public val id: String? = null,
+  public val reverse: Boolean? = null,
+  public val beforeCursor: String? = null,
+  public val afterCursor: String? = null,
+  public val hasBefore: Boolean? = null,
+  public val hasAfter: Boolean? = null,
+  public val activities: List<ActivityItem>? = null,
+)
+---
+/com/example/dto/ActivityItem.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Any
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ActivityItem(
+  public val id: String? = null,
+  public val author: User? = null,
+  public val timestamp: Long? = null,
+  public val removed: Any? = null,
+  public val added: Any? = null,
+  public val target: Any? = null,
+  public val targetMember: String? = null,
+  public val `field`: FilterField? = null,
+  public val category: ActivityCategory? = null,
+)
+---
+/com/example/dto/Agile.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Agile(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val owner: User? = null,
+  public val visibleFor: UserGroup? = null,
+  public val visibleForProjectBased: Boolean? = null,
+  public val updateableBy: UserGroup? = null,
+  public val updateableByProjectBased: Boolean? = null,
+  public val orphansAtTheTop: Boolean? = null,
+  public val hideOrphansSwimlane: Boolean? = null,
+  public val estimationField: CustomField? = null,
+  public val originalEstimationField: CustomField? = null,
+  public val projects: List<Project>? = null,
+  public val sprints: List<Sprint>? = null,
+  public val currentSprint: Sprint? = null,
+  public val columnSettings: ColumnSettings? = null,
+  public val swimlaneSettings: SwimlaneSettings? = null,
+  public val sprintsSettings: SprintsSettings? = null,
+  public val colorCoding: ColorCoding? = null,
+  public val status: AgileStatus? = null,
+)
+---
+/com/example/dto/AgileColumn.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class AgileColumn(
+  public val id: String? = null,
+  public val presentation: String? = null,
+  public val isResolved: Boolean? = null,
+  public val ordinal: Int? = null,
+  public val parent: ColumnSettings? = null,
+  public val wipLimit: WIPLimit? = null,
+  public val fieldValues: List<AgileColumnFieldValue>? = null,
+)
+---
+/com/example/dto/AgileColumnFieldValue.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.String
+
+public data class AgileColumnFieldValue(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val isResolved: Boolean? = null,
+) : DatabaseAttributeValue()
+---
+/com/example/dto/AgileStatus.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class AgileStatus(
+  public val id: String? = null,
+  public val valid: Boolean? = null,
+  public val hasJobs: Boolean? = null,
+  public val errors: List<String>? = null,
+  public val warnings: List<String>? = null,
+)
+---
+/com/example/dto/AppearanceSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class AppearanceSettings(
+  public val id: String? = null,
+  public val timeZone: TimeZoneDescriptor? = null,
+  public val dateFieldFormat: DateFormatDescriptor? = null,
+  public val logo: Logo? = null,
+)
+---
+/com/example/dto/Article.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+public data class Article(
+  public val id: String? = null,
+  public val reporter: User? = null,
+  public val visibility: Visibility? = null,
+  public val summary: String? = null,
+  public val content: String? = null,
+  public val attachments: List<ArticleAttachment>? = null,
+  public val project: Project? = null,
+  public val parentArticle: Article? = null,
+  public val childArticles: List<Article>? = null,
+  public val hasChildren: Boolean? = null,
+  public val updatedBy: User? = null,
+  public val updated: Long? = null,
+  public val created: Long? = null,
+  public val idReadable: String? = null,
+  public val ordinal: Long? = null,
+  public val comments: List<ArticleComment>? = null,
+  public val hasStar: Boolean? = null,
+  public val externalArticle: ExternalArticle? = null,
+) : BaseArticle()
+---
+/com/example/dto/ArticleAttachment.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ArticleAttachment(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val author: User? = null,
+  public val created: Long? = null,
+  public val updated: Long? = null,
+  public val size: Long? = null,
+  public val extension: String? = null,
+  public val charset: String? = null,
+  public val mimeType: String? = null,
+  public val metaData: String? = null,
+  public val draft: Boolean? = null,
+  public val removed: Boolean? = null,
+  public val base64Content: String? = null,
+  public val url: String? = null,
+  public val visibility: Visibility? = null,
+  public val article: BaseArticle? = null,
+  public val comment: ArticleComment? = null,
+)
+---
+/com/example/dto/ArticleComment.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ArticleComment(
+  public val id: String? = null,
+  public val text: String? = null,
+  public val created: Long? = null,
+  public val updated: Long? = null,
+  public val author: User? = null,
+  public val article: Article? = null,
+  public val attachments: List<ArticleAttachment>? = null,
+  public val visibility: Visibility? = null,
+)
+---
+/com/example/dto/AttachmentActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class AttachmentActivityItem(
+  public val id: String? = null,
+  public val target: IssueAttachment? = null,
+  public val removed: List<IssueAttachment>? = null,
+  public val added: List<IssueAttachment>? = null,
+) : CreatedDeletedActivityItem()
+---
+/com/example/dto/AttributeBasedSwimlaneSettings.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class AttributeBasedSwimlaneSettings(
+  public val id: String? = null,
+  public val `field`: FilterField? = null,
+  public val values: List<SwimlaneEntityAttributeValue>? = null,
+) : SwimlaneSettings()
+---
+/com/example/dto/BackupError.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class BackupError(
+  public val id: String? = null,
+  public val date: Long? = null,
+  public val errorMessage: String? = null,
+)
+---
+/com/example/dto/BackupFile.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class BackupFile(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val size: Long? = null,
+  public val creationDate: Long? = null,
+  public val link: String? = null,
+)
+---
+/com/example/dto/BackupStatus.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class BackupStatus(
+  public val id: String? = null,
+  public val backupInProgress: Boolean? = null,
+  public val backupCancelled: Boolean? = null,
+  public val backupError: BackupError? = null,
+)
+---
+/com/example/dto/BaseArticle.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class BaseArticle(
+  public val id: String? = null,
+  public val reporter: User? = null,
+  public val visibility: Visibility? = null,
+  public val summary: String? = null,
+  public val content: String? = null,
+  public val attachments: List<ArticleAttachment>? = null,
+)
+---
+/com/example/dto/BaseBundle.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class BaseBundle(
+  public val id: String? = null,
+  public val values: List<BundleElement>? = null,
+) : Bundle()
+---
+/com/example/dto/BaseWorkItem.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class BaseWorkItem(
+  public val id: String? = null,
+)
+---
+/com/example/dto/BitBucketChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class BitBucketChangesProcessor(
+  public val id: String? = null,
+  public val server: BitBucketServer? = null,
+) : VcsHostingChangesProcessor()
+---
+/com/example/dto/BitBucketServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class BitBucketServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsHostingServer()
+---
+/com/example/dto/BitbucketStandaloneChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class BitbucketStandaloneChangesProcessor(
+  public val id: String? = null,
+  public val server: BitbucketStandaloneServer? = null,
+) : VcsHostingChangesProcessor()
+---
+/com/example/dto/BitbucketStandaloneServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class BitbucketStandaloneServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsHostingServer()
+---
+/com/example/dto/BuildBundle.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class BuildBundle(
+  public val id: String? = null,
+  public val values: List<BuildBundleElement>? = null,
+) : BaseBundle()
+---
+/com/example/dto/BuildBundleCustomFieldDefaults.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class BuildBundleCustomFieldDefaults(
+  public val id: String? = null,
+  public val bundle: BuildBundle? = null,
+  public val defaultValues: List<BuildBundleElement>? = null,
+) : BundleCustomFieldDefaults()
+---
+/com/example/dto/BuildBundleElement.kt
+package com.example.dto
+
+import kotlin.Long
+import kotlin.String
+
+public data class BuildBundleElement(
+  public val id: String? = null,
+  public val assembleDate: Long? = null,
+) : BundleElement()
+---
+/com/example/dto/BuildProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class BuildProjectCustomField(
+  public val id: String? = null,
+  public val bundle: BuildBundle? = null,
+  public val defaultValues: List<BuildBundleElement>? = null,
+) : BundleProjectCustomField()
+---
+/com/example/dto/Bundle.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Bundle(
+  public val id: String? = null,
+  public val isUpdateable: Boolean? = null,
+)
+---
+/com/example/dto/BundleCustomFieldDefaults.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class BundleCustomFieldDefaults(
+  public val id: String? = null,
+) : CustomFieldDefaults()
+---
+/com/example/dto/BundleElement.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class BundleElement(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val bundle: Bundle? = null,
+  public val description: String? = null,
+  public val ordinal: Int? = null,
+  public val color: FieldStyle? = null,
+  public val hasRunningJob: Boolean? = null,
+)
+---
+/com/example/dto/BundleProjectCustomField.kt
+package com.example.dto
+
+public object BundleProjectCustomField : ProjectCustomField()
+---
+/com/example/dto/ChangesProcessor.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ChangesProcessor(
+  public val id: String? = null,
+  public val server: VcsServer? = null,
+  public val project: Project? = null,
+  public val relatedProjects: List<Project>? = null,
+  public val enabled: Boolean? = null,
+  public val visibleForGroups: List<UserGroup>? = null,
+  public val addComments: Boolean? = null,
+  public val lookupIssuesInBranchName: Boolean? = null,
+)
+---
+/com/example/dto/ColorCoding.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ColorCoding(
+  public val id: String? = null,
+)
+---
+/com/example/dto/ColumnSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ColumnSettings(
+  public val id: String? = null,
+  public val `field`: CustomField? = null,
+  public val columns: List<AgileColumn>? = null,
+)
+---
+/com/example/dto/CommandLimitedVisibility.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class CommandLimitedVisibility(
+  public val id: String? = null,
+  public val permittedGroups: List<UserGroup>? = null,
+  public val permittedUsers: List<User>? = null,
+) : CommandVisibility()
+---
+/com/example/dto/CommandList.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class CommandList(
+  public val id: String? = null,
+  public val comment: String? = null,
+  public val visibility: CommandVisibility? = null,
+  public val query: String? = null,
+  public val caret: Int? = null,
+  public val silent: Boolean? = null,
+  public val usesMarkdown: Boolean? = null,
+  public val runAs: String? = null,
+  public val commands: List<ParsedCommand>? = null,
+  public val issues: List<Issue>? = null,
+  public val suggestions: List<Suggestion>? = null,
+)
+---
+/com/example/dto/CommandUnlimitedVisibility.kt
+package com.example.dto
+
+public object CommandUnlimitedVisibility : CommandVisibility()
+---
+/com/example/dto/CommandVisibility.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class CommandVisibility(
+  public val id: String? = null,
+)
+---
+/com/example/dto/CommentActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class CommentActivityItem(
+  public val id: String? = null,
+  public val target: IssueComment? = null,
+  public val removed: List<IssueComment>? = null,
+  public val added: List<IssueComment>? = null,
+  public val authorGroup: UserGroup? = null,
+) : CreatedDeletedActivityItem()
+---
+/com/example/dto/CommentAttachmentsActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class CommentAttachmentsActivityItem(
+  public val id: String? = null,
+  public val target: IssueComment? = null,
+  public val removed: List<IssueAttachment>? = null,
+  public val added: List<IssueAttachment>? = null,
+) : MultiValueActivityItem()
+---
+/com/example/dto/CreatedDeletedActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class CreatedDeletedActivityItem(
+  public val id: String? = null,
+) : ActivityItem()
+---
+/com/example/dto/CustomField.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class CustomField(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val localizedName: String? = null,
+  public val fieldType: FieldType? = null,
+  public val isAutoAttached: Boolean? = null,
+  public val isDisplayedInIssueList: Boolean? = null,
+  public val ordinal: Int? = null,
+  public val aliases: String? = null,
+  public val fieldDefaults: CustomFieldDefaults? = null,
+  public val hasRunningJob: Boolean? = null,
+  public val isUpdateable: Boolean? = null,
+  public val instances: List<ProjectCustomField>? = null,
+)
+---
+/com/example/dto/CustomFieldActivityItem.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class CustomFieldActivityItem(
+  public val id: String? = null,
+  public val target: Issue? = null,
+  public val removed: Any? = null,
+  public val added: Any? = null,
+) : ActivityItem()
+---
+/com/example/dto/CustomFieldCondition.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class CustomFieldCondition(
+  public val id: String? = null,
+  public val parent: ProjectCustomField? = null,
+)
+---
+/com/example/dto/CustomFieldDefaults.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class CustomFieldDefaults(
+  public val id: String? = null,
+  public val canBeEmpty: Boolean? = null,
+  public val emptyFieldText: String? = null,
+  public val isPublic: Boolean? = null,
+  public val parent: CustomField? = null,
+)
+---
+/com/example/dto/CustomFilterField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class CustomFilterField(
+  public val id: String? = null,
+  public val customField: CustomField? = null,
+) : FilterField()
+---
+/com/example/dto/DatabaseAttributeValue.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class DatabaseAttributeValue(
+  public val id: String? = null,
+)
+---
+/com/example/dto/DatabaseBackupSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class DatabaseBackupSettings(
+  public val id: String? = null,
+  public val location: String? = null,
+  public val filesToKeep: Int? = null,
+  public val cronExpression: String? = null,
+  public val archiveFormat: ArchiveFormat? = null,
+  public val isOn: Boolean? = null,
+  public val availableDiskSpace: Long? = null,
+  public val notifiedUsers: List<User>? = null,
+  public val backupStatus: BackupStatus? = null,
+) {
+  public enum class ArchiveFormat {
+    TAR_GZ,
+    ZIP,
+  }
+}
+---
+/com/example/dto/DatabaseMultiValueIssueCustomField.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class DatabaseMultiValueIssueCustomField(
+  public val id: String? = null,
+  public val `value`: Any? = null,
+) : IssueCustomField()
+---
+/com/example/dto/DatabaseSingleValueIssueCustomField.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class DatabaseSingleValueIssueCustomField(
+  public val id: String? = null,
+  public val `value`: Any? = null,
+) : IssueCustomField()
+---
+/com/example/dto/DateFormatDescriptor.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class DateFormatDescriptor(
+  public val id: String? = null,
+  public val presentation: String? = null,
+  public val pattern: String? = null,
+  public val datePattern: String? = null,
+)
+---
+/com/example/dto/DateIssueCustomField.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class DateIssueCustomField(
+  public val id: String? = null,
+  public val `value`: Any? = null,
+) : SimpleIssueCustomField()
+---
+/com/example/dto/DuplicateVote.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class DuplicateVote(
+  public val id: String? = null,
+  public val issue: Issue? = null,
+  public val user: User? = null,
+)
+---
+/com/example/dto/DurationValue.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class DurationValue(
+  public val id: String? = null,
+  public val minutes: Int? = null,
+  public val presentation: String? = null,
+)
+---
+/com/example/dto/EmailSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class EmailSettings(
+  public val id: String? = null,
+  public val isEnabled: Boolean? = null,
+  public val host: String? = null,
+  public val port: Int? = null,
+  public val mailProtocol: MailProtocol? = null,
+  public val anonymous: Boolean? = null,
+  public val login: String? = null,
+  public val sslKey: StorageEntry? = null,
+  public val from: String? = null,
+  public val replyTo: String? = null,
+) {
+  public enum class MailProtocol {
+    SMTP,
+    SMTPS,
+    SMTP_TLS,
+  }
+}
+---
+/com/example/dto/EnumBundle.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class EnumBundle(
+  public val id: String? = null,
+  public val values: List<EnumBundleElement>? = null,
+) : BaseBundle()
+---
+/com/example/dto/EnumBundleCustomFieldDefaults.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class EnumBundleCustomFieldDefaults(
+  public val id: String? = null,
+  public val bundle: EnumBundle? = null,
+  public val defaultValues: List<EnumBundleElement>? = null,
+) : BundleCustomFieldDefaults()
+---
+/com/example/dto/EnumBundleElement.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class EnumBundleElement(
+  public val id: String? = null,
+) : LocalizableBundleElement()
+---
+/com/example/dto/EnumProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class EnumProjectCustomField(
+  public val id: String? = null,
+  public val bundle: EnumBundle? = null,
+  public val defaultValues: List<EnumBundleElement>? = null,
+) : BundleProjectCustomField()
+---
+/com/example/dto/Event.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Event(
+  public val id: String? = null,
+  public val presentation: String? = null,
+)
+---
+/com/example/dto/ExternalArticle.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ExternalArticle(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val url: String? = null,
+  public val key: String? = null,
+)
+---
+/com/example/dto/ExternalIssue.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ExternalIssue(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val url: String? = null,
+  public val key: String? = null,
+)
+---
+/com/example/dto/FieldBasedColorCoding.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class FieldBasedColorCoding(
+  public val id: String? = null,
+  public val prototype: CustomField? = null,
+) : ColorCoding()
+---
+/com/example/dto/FieldBasedCondition.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+public data class FieldBasedCondition(
+  public val id: String? = null,
+  public val `field`: BundleProjectCustomField? = null,
+  public val values: List<BundleElement>? = null,
+  public val showForNullValue: Boolean? = null,
+) : CustomFieldCondition()
+---
+/com/example/dto/FieldStyle.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class FieldStyle(
+  public val id: String? = null,
+  public val background: String? = null,
+  public val foreground: String? = null,
+)
+---
+/com/example/dto/FieldType.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class FieldType(
+  public val id: String? = null,
+)
+---
+/com/example/dto/FilterField.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class FilterField(
+  public val id: String? = null,
+  public val presentation: String? = null,
+  public val name: String? = null,
+)
+---
+/com/example/dto/GeneralUserProfile.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class GeneralUserProfile(
+  public val id: String? = null,
+  public val dateFieldFormat: DateFormatDescriptor? = null,
+  public val timezone: TimeZoneDescriptor? = null,
+  public val locale: LocaleDescriptor? = null,
+)
+---
+/com/example/dto/GiteaChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class GiteaChangesProcessor(
+  public val id: String? = null,
+  public val server: GiteaServer? = null,
+) : VcsHostingChangesProcessor()
+---
+/com/example/dto/GiteaServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class GiteaServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsHostingServer()
+---
+/com/example/dto/GitHubChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class GitHubChangesProcessor(
+  public val id: String? = null,
+  public val server: GitHubServer? = null,
+) : VcsHostingChangesProcessor()
+---
+/com/example/dto/GitHubServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class GitHubServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsHostingServer()
+---
+/com/example/dto/GitLabChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class GitLabChangesProcessor(
+  public val id: String? = null,
+  public val server: GitLabServer? = null,
+) : VcsHostingChangesProcessor()
+---
+/com/example/dto/GitLabServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class GitLabServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsHostingServer()
+---
+/com/example/dto/GlobalSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class GlobalSettings(
+  public val id: String? = null,
+  public val systemSettings: SystemSettings? = null,
+  public val notificationSettings: NotificationSettings? = null,
+  public val restSettings: RestCorsSettings? = null,
+  public val appearanceSettings: AppearanceSettings? = null,
+  public val localeSettings: LocaleSettings? = null,
+  public val license: License? = null,
+)
+---
+/com/example/dto/GlobalTimeTrackingSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class GlobalTimeTrackingSettings(
+  public val id: String? = null,
+  public val workItemTypes: List<WorkItemType>? = null,
+  public val workTimeSettings: WorkTimeSettings? = null,
+  public val attributePrototypes: List<WorkItemAttributePrototype>? = null,
+)
+---
+/com/example/dto/GogsChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class GogsChangesProcessor(
+  public val id: String? = null,
+  public val server: GogsServer? = null,
+) : VcsHostingChangesProcessor()
+---
+/com/example/dto/GogsServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class GogsServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsHostingServer()
+---
+/com/example/dto/GroupProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class GroupProjectCustomField(
+  public val id: String? = null,
+  public val defaultValues: List<UserGroup>? = null,
+) : ProjectCustomField()
+---
+/com/example/dto/Issue.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Issue(
+  public val id: String? = null,
+  public val idReadable: String? = null,
+  public val created: Long? = null,
+  public val updated: Long? = null,
+  public val resolved: Long? = null,
+  public val numberInProject: Long? = null,
+  public val project: Project? = null,
+  public val summary: String? = null,
+  public val description: String? = null,
+  public val usesMarkdown: Boolean? = null,
+  public val wikifiedDescription: String? = null,
+  public val reporter: User? = null,
+  public val updater: User? = null,
+  public val draftOwner: User? = null,
+  public val isDraft: Boolean? = null,
+  public val visibility: Visibility? = null,
+  public val votes: Int? = null,
+  public val comments: List<IssueComment>? = null,
+  public val commentsCount: Int? = null,
+  public val tags: List<IssueTag>? = null,
+  public val links: List<IssueLink>? = null,
+  public val externalIssue: ExternalIssue? = null,
+  public val customFields: List<IssueCustomField>? = null,
+  public val voters: IssueVoters? = null,
+  public val watchers: IssueWatchers? = null,
+  public val attachments: List<IssueAttachment>? = null,
+  public val subtasks: IssueLink? = null,
+  public val parent: IssueLink? = null,
+)
+---
+/com/example/dto/IssueAttachment.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueAttachment(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val author: User? = null,
+  public val created: Long? = null,
+  public val updated: Long? = null,
+  public val size: Long? = null,
+  public val extension: String? = null,
+  public val charset: String? = null,
+  public val mimeType: String? = null,
+  public val metaData: String? = null,
+  public val draft: Boolean? = null,
+  public val removed: Boolean? = null,
+  public val base64Content: String? = null,
+  public val url: String? = null,
+  public val visibility: Visibility? = null,
+  public val issue: Issue? = null,
+  public val comment: IssueComment? = null,
+  public val thumbnailURL: String? = null,
+)
+---
+/com/example/dto/IssueBasedSwimlaneSettings.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class IssueBasedSwimlaneSettings(
+  public val id: String? = null,
+  public val `field`: FilterField? = null,
+  public val defaultCardType: SwimlaneValue? = null,
+  public val values: List<SwimlaneValue>? = null,
+) : SwimlaneSettings()
+---
+/com/example/dto/IssueComment.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueComment(
+  public val id: String? = null,
+  public val text: String? = null,
+  public val usesMarkdown: Boolean? = null,
+  public val textPreview: String? = null,
+  public val created: Long? = null,
+  public val updated: Long? = null,
+  public val author: User? = null,
+  public val issue: Issue? = null,
+  public val attachments: List<IssueAttachment>? = null,
+  public val visibility: Visibility? = null,
+  public val deleted: Boolean? = null,
+)
+---
+/com/example/dto/IssueCountResponse.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueCountResponse(
+  public val id: String? = null,
+  public val count: Long? = null,
+  public val unresolvedOnly: Boolean? = null,
+  public val query: String? = null,
+  public val folder: IssueFolder? = null,
+)
+---
+/com/example/dto/IssueCreatedActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class IssueCreatedActivityItem(
+  public val id: String? = null,
+  public val target: Issue? = null,
+  public val removed: List<Issue>? = null,
+  public val added: List<Issue>? = null,
+) : CreatedDeletedActivityItem()
+---
+/com/example/dto/IssueCustomField.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Any
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueCustomField(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val projectCustomField: ProjectCustomField? = null,
+  public val `value`: Any? = null,
+)
+---
+/com/example/dto/IssueFolder.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueFolder(
+  public val id: String? = null,
+  public val name: String? = null,
+)
+---
+/com/example/dto/IssueLink.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueLink(
+  public val id: String? = null,
+  public val direction: Direction? = null,
+  public val linkType: IssueLinkType? = null,
+  public val issues: List<Issue>? = null,
+  public val trimmedIssues: List<Issue>? = null,
+) {
+  public enum class Direction {
+    OUTWARD,
+    INWARD,
+    BOTH,
+  }
+}
+---
+/com/example/dto/IssueLinkType.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueLinkType(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val localizedName: String? = null,
+  public val sourceToTarget: String? = null,
+  public val localizedSourceToTarget: String? = null,
+  public val targetToSource: String? = null,
+  public val localizedTargetToSource: String? = null,
+  public val directed: Boolean? = null,
+  public val aggregation: Boolean? = null,
+  public val readOnly: Boolean? = null,
+)
+---
+/com/example/dto/IssueResolvedActivityItem.kt
+package com.example.dto
+
+import kotlin.Long
+import kotlin.String
+
+public data class IssueResolvedActivityItem(
+  public val id: String? = null,
+  public val removed: Long? = null,
+  public val added: Long? = null,
+) : SimpleValueActivityItem()
+---
+/com/example/dto/IssueTag.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+public data class IssueTag(
+  public val id: String? = null,
+  public val issues: List<Issue>? = null,
+  public val color: FieldStyle? = null,
+  public val untagOnResolve: Boolean? = null,
+  public val visibleFor: UserGroup? = null,
+  public val updateableBy: UserGroup? = null,
+  public val readSharingSettings: WatchFolderSharingSettings? = null,
+  public val updateSharingSettings: WatchFolderSharingSettings? = null,
+) : WatchFolder()
+---
+/com/example/dto/IssueTimeTracker.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueTimeTracker(
+  public val id: String? = null,
+  public val workItems: List<IssueWorkItem>? = null,
+  public val enabled: Boolean? = null,
+)
+---
+/com/example/dto/IssueVoters.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueVoters(
+  public val id: String? = null,
+  public val hasVote: Boolean? = null,
+  public val original: List<User>? = null,
+  public val duplicate: List<DuplicateVote>? = null,
+)
+---
+/com/example/dto/IssueWatcher.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueWatcher(
+  public val id: String? = null,
+  public val user: User? = null,
+  public val issue: Issue? = null,
+  public val isStarred: Boolean? = null,
+)
+---
+/com/example/dto/IssueWatchers.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class IssueWatchers(
+  public val id: String? = null,
+  public val hasStar: Boolean? = null,
+  public val issueWatchers: List<IssueWatcher>? = null,
+  public val duplicateWatchers: List<IssueWatcher>? = null,
+)
+---
+/com/example/dto/IssueWorkItem.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+public data class IssueWorkItem(
+  public val id: String? = null,
+  public val author: User? = null,
+  public val creator: User? = null,
+  public val text: String? = null,
+  public val textPreview: String? = null,
+  public val type: WorkItemType? = null,
+  public val created: Long? = null,
+  public val updated: Long? = null,
+  public val duration: DurationValue? = null,
+  public val date: Long? = null,
+  public val issue: Issue? = null,
+  public val usesMarkdown: Boolean? = null,
+  public val attributes: List<WorkItemAttribute>? = null,
+) : BaseWorkItem()
+---
+/com/example/dto/JabberSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class JabberSettings(
+  public val id: String? = null,
+  public val isEnabled: Boolean? = null,
+  public val host: String? = null,
+  public val port: Int? = null,
+  public val login: String? = null,
+  public val serviceName: String? = null,
+)
+---
+/com/example/dto/JenkinsChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class JenkinsChangesProcessor(
+  public val id: String? = null,
+  public val server: JenkinsServer? = null,
+) : ChangesProcessor()
+---
+/com/example/dto/JenkinsServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class JenkinsServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsServer()
+---
+/com/example/dto/License.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class License(
+  public val id: String? = null,
+  public val username: String? = null,
+  public val license: String? = null,
+  public val error: String? = null,
+)
+---
+/com/example/dto/LimitedVisibility.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class LimitedVisibility(
+  public val id: String? = null,
+  public val permittedGroups: List<UserGroup>? = null,
+  public val permittedUsers: List<User>? = null,
+) : Visibility()
+---
+/com/example/dto/LinksActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class LinksActivityItem(
+  public val id: String? = null,
+  public val target: Issue? = null,
+  public val removed: List<Issue>? = null,
+  public val added: List<Issue>? = null,
+) : MultiValueActivityItem()
+---
+/com/example/dto/LocaleDescriptor.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class LocaleDescriptor(
+  public val id: String? = null,
+  public val locale: String? = null,
+  public val language: String? = null,
+  public val community: Boolean? = null,
+  public val name: String? = null,
+)
+---
+/com/example/dto/LocaleSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class LocaleSettings(
+  public val id: String? = null,
+  public val locale: LocaleDescriptor? = null,
+  public val isRTL: Boolean? = null,
+)
+---
+/com/example/dto/LocalizableBundleElement.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class LocalizableBundleElement(
+  public val id: String? = null,
+  public val localizedName: String? = null,
+) : BundleElement()
+---
+/com/example/dto/Logo.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Logo(
+  public val id: String? = null,
+  public val url: String? = null,
+)
+---
+/com/example/dto/Me.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class Me(
+  public val id: String? = null,
+) : User()
+---
+/com/example/dto/MultiBuildIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class MultiBuildIssueCustomField(
+  public val id: String? = null,
+  public val `value`: List<BuildBundleElement>? = null,
+) : DatabaseMultiValueIssueCustomField()
+---
+/com/example/dto/MultiEnumIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class MultiEnumIssueCustomField(
+  public val id: String? = null,
+  public val `value`: List<EnumBundleElement>? = null,
+) : DatabaseMultiValueIssueCustomField()
+---
+/com/example/dto/MultiGroupIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class MultiGroupIssueCustomField(
+  public val id: String? = null,
+  public val `value`: List<UserGroup>? = null,
+) : DatabaseMultiValueIssueCustomField()
+---
+/com/example/dto/MultiOwnedIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class MultiOwnedIssueCustomField(
+  public val id: String? = null,
+  public val `value`: List<OwnedBundleElement>? = null,
+) : DatabaseMultiValueIssueCustomField()
+---
+/com/example/dto/MultiUserIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class MultiUserIssueCustomField(
+  public val id: String? = null,
+  public val `value`: List<User>? = null,
+) : DatabaseMultiValueIssueCustomField()
+---
+/com/example/dto/MultiValueActivityItem.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class MultiValueActivityItem(
+  public val id: String? = null,
+  public val removed: Any? = null,
+  public val added: Any? = null,
+) : ActivityItem()
+---
+/com/example/dto/MultiVersionIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class MultiVersionIssueCustomField(
+  public val id: String? = null,
+  public val `value`: List<VersionBundleElement>? = null,
+) : DatabaseMultiValueIssueCustomField()
+---
+/com/example/dto/NotificationSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class NotificationSettings(
+  public val id: String? = null,
+  public val emailSettings: EmailSettings? = null,
+  public val jabberSettings: JabberSettings? = null,
+)
+---
+/com/example/dto/NotificationsUserProfile.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class NotificationsUserProfile(
+  public val id: String? = null,
+  public val notifyOnOwnChanges: Boolean? = null,
+  public val jabberNotificationsEnabled: Boolean? = null,
+  public val emailNotificationsEnabled: Boolean? = null,
+  public val mentionNotificationsEnabled: Boolean? = null,
+  public val duplicateClusterNotificationsEnabled: Boolean? = null,
+  public val mailboxIntegrationNotificationsEnabled: Boolean? = null,
+  public val usePlainTextEmails: Boolean? = null,
+  public val autoWatchOnComment: Boolean? = null,
+  public val autoWatchOnCreate: Boolean? = null,
+  public val autoWatchOnVote: Boolean? = null,
+  public val autoWatchOnUpdate: Boolean? = null,
+)
+---
+/com/example/dto/OnlineUsers.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class OnlineUsers(
+  public val id: String? = null,
+  public val users: Int? = null,
+)
+---
+/com/example/dto/OwnedBundle.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class OwnedBundle(
+  public val id: String? = null,
+  public val values: List<OwnedBundleElement>? = null,
+) : BaseBundle()
+---
+/com/example/dto/OwnedBundleCustomFieldDefaults.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class OwnedBundleCustomFieldDefaults(
+  public val id: String? = null,
+  public val bundle: OwnedBundle? = null,
+  public val defaultValues: List<OwnedBundleElement>? = null,
+) : BundleCustomFieldDefaults()
+---
+/com/example/dto/OwnedBundleElement.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class OwnedBundleElement(
+  public val id: String? = null,
+  public val owner: User? = null,
+) : BundleElement()
+---
+/com/example/dto/OwnedProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class OwnedProjectCustomField(
+  public val id: String? = null,
+  public val bundle: OwnedBundle? = null,
+  public val defaultValues: List<OwnedBundleElement>? = null,
+) : BundleProjectCustomField()
+---
+/com/example/dto/ParsedCommand.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ParsedCommand(
+  public val id: String? = null,
+  public val description: String? = null,
+  public val error: Boolean? = null,
+  public val delete: Boolean? = null,
+)
+---
+/com/example/dto/PeriodFieldFormat.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class PeriodFieldFormat(
+  public val id: String? = null,
+)
+---
+/com/example/dto/PeriodIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class PeriodIssueCustomField(
+  public val id: String? = null,
+  public val `value`: PeriodValue? = null,
+) : IssueCustomField()
+---
+/com/example/dto/PeriodProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class PeriodProjectCustomField(
+  public val id: String? = null,
+) : ProjectCustomField()
+---
+/com/example/dto/PeriodValue.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class PeriodValue(
+  public val id: String? = null,
+  public val minutes: Int? = null,
+  public val presentation: String? = null,
+)
+---
+/com/example/dto/PredefinedFilterField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class PredefinedFilterField(
+  public val id: String? = null,
+) : FilterField()
+---
+/com/example/dto/Project.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+public data class Project(
+  public val id: String? = null,
+  public val startingNumber: Long? = null,
+  public val shortName: String? = null,
+  public val description: String? = null,
+  public val leader: User? = null,
+  public val createdBy: User? = null,
+  public val issues: List<Issue>? = null,
+  public val customFields: Any? = null,
+  public val archived: Boolean? = null,
+  public val fromEmail: String? = null,
+  public val replyToEmail: String? = null,
+  public val template: Boolean? = null,
+  public val iconUrl: String? = null,
+  public val team: UserGroup? = null,
+) : IssueFolder()
+---
+/com/example/dto/ProjectActivityItem.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class ProjectActivityItem(
+  public val id: String? = null,
+  public val target: Issue? = null,
+  public val removed: Any? = null,
+  public val added: Any? = null,
+) : SingleValueActivityItem()
+---
+/com/example/dto/ProjectBasedColorCoding.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class ProjectBasedColorCoding(
+  public val id: String? = null,
+  public val projectColors: List<ProjectColor>? = null,
+) : ColorCoding()
+---
+/com/example/dto/ProjectColor.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ProjectColor(
+  public val id: String? = null,
+  public val project: Project? = null,
+  public val color: FieldStyle? = null,
+)
+---
+/com/example/dto/ProjectCustomField.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ProjectCustomField(
+  public val id: String? = null,
+  public val `field`: CustomField? = null,
+  public val project: Project? = null,
+  public val canBeEmpty: Boolean? = null,
+  public val emptyFieldText: String? = null,
+  public val ordinal: Int? = null,
+  public val isPublic: Boolean? = null,
+  public val hasRunningJob: Boolean? = null,
+  public val condition: CustomFieldCondition? = null,
+)
+---
+/com/example/dto/ProjectTimeTrackingSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class ProjectTimeTrackingSettings(
+  public val id: String? = null,
+  public val enabled: Boolean? = null,
+  public val estimate: ProjectCustomField? = null,
+  public val timeSpent: ProjectCustomField? = null,
+  public val workItemTypes: List<WorkItemType>? = null,
+  public val project: Project? = null,
+  public val attributes: List<WorkItemProjectAttribute>? = null,
+)
+---
+/com/example/dto/RestCorsSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class RestCorsSettings(
+  public val id: String? = null,
+  public val allowedOrigins: List<String>? = null,
+  public val allowAllOrigins: Boolean? = null,
+)
+---
+/com/example/dto/SavedQuery.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class SavedQuery(
+  public val id: String? = null,
+  public val query: String? = null,
+  public val issues: List<Issue>? = null,
+  public val visibleFor: UserGroup? = null,
+  public val updateableBy: UserGroup? = null,
+  public val readSharingSettings: WatchFolderSharingSettings? = null,
+  public val updateSharingSettings: WatchFolderSharingSettings? = null,
+) : WatchFolder()
+---
+/com/example/dto/SearchSuggestions.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class SearchSuggestions(
+  public val id: String? = null,
+  public val caret: Int? = null,
+  public val ignoreUnresolvedSetting: Boolean? = null,
+  public val query: String? = null,
+  public val suggestions: List<Suggestion>? = null,
+  public val folders: List<IssueFolder>? = null,
+)
+---
+/com/example/dto/SimpleIssueCustomField.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class SimpleIssueCustomField(
+  public val id: String? = null,
+  public val `value`: Any? = null,
+) : IssueCustomField()
+---
+/com/example/dto/SimpleProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SimpleProjectCustomField(
+  public val id: String? = null,
+) : ProjectCustomField()
+---
+/com/example/dto/SimpleValueActivityItem.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class SimpleValueActivityItem(
+  public val id: String? = null,
+  public val removed: Any? = null,
+  public val added: Any? = null,
+) : SingleValueActivityItem()
+---
+/com/example/dto/SingleBuildIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SingleBuildIssueCustomField(
+  public val id: String? = null,
+  public val `value`: BuildBundleElement? = null,
+) : DatabaseSingleValueIssueCustomField()
+---
+/com/example/dto/SingleEnumIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SingleEnumIssueCustomField(
+  public val id: String? = null,
+  public val `value`: EnumBundleElement? = null,
+) : DatabaseSingleValueIssueCustomField()
+---
+/com/example/dto/SingleGroupIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SingleGroupIssueCustomField(
+  public val id: String? = null,
+  public val `value`: UserGroup? = null,
+) : DatabaseSingleValueIssueCustomField()
+---
+/com/example/dto/SingleOwnedIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SingleOwnedIssueCustomField(
+  public val id: String? = null,
+  public val `value`: OwnedBundleElement? = null,
+) : DatabaseSingleValueIssueCustomField()
+---
+/com/example/dto/SingleUserIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SingleUserIssueCustomField(
+  public val id: String? = null,
+  public val `value`: User? = null,
+) : DatabaseSingleValueIssueCustomField()
+---
+/com/example/dto/SingleValueActivityItem.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+
+public data class SingleValueActivityItem(
+  public val id: String? = null,
+  public val removed: Any? = null,
+  public val added: Any? = null,
+) : ActivityItem()
+---
+/com/example/dto/SingleVersionIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SingleVersionIssueCustomField(
+  public val id: String? = null,
+  public val `value`: VersionBundleElement? = null,
+) : DatabaseSingleValueIssueCustomField()
+---
+/com/example/dto/SpaceChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SpaceChangesProcessor(
+  public val id: String? = null,
+  public val server: SpaceServer? = null,
+) : VcsHostingChangesProcessor()
+---
+/com/example/dto/SpaceServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class SpaceServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsHostingServer()
+---
+/com/example/dto/Sprint.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Sprint(
+  public val id: String? = null,
+  public val agile: Agile? = null,
+  public val name: String? = null,
+  public val goal: String? = null,
+  public val start: Long? = null,
+  public val finish: Long? = null,
+  public val archived: Boolean? = null,
+  public val isDefault: Boolean? = null,
+  public val issues: List<Issue>? = null,
+  public val unresolvedIssuesCount: Int? = null,
+  public val previousSprint: Sprint? = null,
+)
+---
+/com/example/dto/SprintActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class SprintActivityItem(
+  public val id: String? = null,
+  public val target: Issue? = null,
+  public val removed: List<Sprint>? = null,
+  public val added: List<Sprint>? = null,
+) : MultiValueActivityItem()
+---
+/com/example/dto/SprintsSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class SprintsSettings(
+  public val id: String? = null,
+  public val isExplicit: Boolean? = null,
+  public val cardOnSeveralSprints: Boolean? = null,
+  public val defaultSprint: Sprint? = null,
+  public val disableSprints: Boolean? = null,
+  public val explicitQuery: String? = null,
+  public val sprintSyncField: CustomField? = null,
+  public val hideSubtasksOfCards: Boolean? = null,
+)
+---
+/com/example/dto/StateBundle.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class StateBundle(
+  public val id: String? = null,
+  public val values: List<StateBundleElement>? = null,
+) : BaseBundle()
+---
+/com/example/dto/StateBundleCustomFieldDefaults.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class StateBundleCustomFieldDefaults(
+  public val id: String? = null,
+  public val bundle: StateBundle? = null,
+  public val defaultValues: List<StateBundleElement>? = null,
+) : BundleCustomFieldDefaults()
+---
+/com/example/dto/StateBundleElement.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.String
+
+public data class StateBundleElement(
+  public val id: String? = null,
+  public val isResolved: Boolean? = null,
+) : LocalizableBundleElement()
+---
+/com/example/dto/StateIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class StateIssueCustomField(
+  public val id: String? = null,
+  public val `value`: StateBundleElement? = null,
+) : DatabaseSingleValueIssueCustomField()
+---
+/com/example/dto/StateMachineIssueCustomField.kt
+package com.example.dto
+
+import kotlin.Any
+import kotlin.String
+import kotlin.collections.List
+
+public data class StateMachineIssueCustomField(
+  public val id: String? = null,
+  public val `value`: Any? = null,
+  public val event: Event? = null,
+  public val possibleEvents: List<Event>? = null,
+) : DatabaseSingleValueIssueCustomField()
+---
+/com/example/dto/StateProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class StateProjectCustomField(
+  public val id: String? = null,
+  public val bundle: StateBundle? = null,
+  public val defaultValues: List<StateBundleElement>? = null,
+) : BundleProjectCustomField()
+---
+/com/example/dto/StorageEntry.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class StorageEntry(
+  public val id: String? = null,
+  public val name: String? = null,
+)
+---
+/com/example/dto/Suggestion.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Suggestion(
+  public val id: String? = null,
+  public val completionStart: Int? = null,
+  public val completionEnd: Int? = null,
+  public val matchingStart: Int? = null,
+  public val matchingEnd: Int? = null,
+  public val caret: Int? = null,
+  public val description: String? = null,
+  public val option: String? = null,
+  public val prefix: String? = null,
+  public val suffix: String? = null,
+  public val group: String? = null,
+  public val icon: String? = null,
+  public val auxiliaryIcon: String? = null,
+  public val className: String? = null,
+)
+---
+/com/example/dto/SwimlaneEntityAttributeValue.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.String
+
+public data class SwimlaneEntityAttributeValue(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val isResolved: Boolean? = null,
+) : DatabaseAttributeValue()
+---
+/com/example/dto/SwimlaneSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class SwimlaneSettings(
+  public val id: String? = null,
+  public val enabled: Boolean? = null,
+)
+---
+/com/example/dto/SwimlaneValue.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class SwimlaneValue(
+  public val id: String? = null,
+  public val name: String? = null,
+)
+---
+/com/example/dto/SystemSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class SystemSettings(
+  public val id: String? = null,
+  public val baseUrl: String? = null,
+  public val maxUploadFileSize: Long? = null,
+  public val maxExportItems: Int? = null,
+  public val administratorEmail: String? = null,
+  public val allowStatisticsCollection: Boolean? = null,
+  public val isApplicationReadOnly: Boolean? = null,
+)
+---
+/com/example/dto/TagsActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class TagsActivityItem(
+  public val id: String? = null,
+  public val target: Issue? = null,
+  public val removed: List<IssueTag>? = null,
+  public val added: List<IssueTag>? = null,
+) : MultiValueActivityItem()
+---
+/com/example/dto/TeamcityChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class TeamcityChangesProcessor(
+  public val id: String? = null,
+  public val server: TeamcityServer? = null,
+) : ChangesProcessor()
+---
+/com/example/dto/TeamcityServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class TeamcityServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsServer()
+---
+/com/example/dto/Telemetry.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Telemetry(
+  public val id: String? = null,
+  public val installationFolder: String? = null,
+  public val databaseLocation: String? = null,
+  public val logsLocation: String? = null,
+  public val availableProcessors: Int? = null,
+  public val availableMemory: String? = null,
+  public val allocatedMemory: String? = null,
+  public val usedMemory: String? = null,
+  public val uptime: String? = null,
+  public val startedTime: Long? = null,
+  public val databaseBackgroundThreads: Int? = null,
+  public val pendingAsyncJobs: Int? = null,
+  public val cachedResultsCountInDBQueriesCache: Int? = null,
+  public val databaseQueriesCacheHitRate: String? = null,
+  public val blobStringsCacheHitRate: String? = null,
+  public val totalTransactions: Long? = null,
+  public val transactionsPerSecond: String? = null,
+  public val requestsPerSecond: String? = null,
+  public val databaseSize: String? = null,
+  public val fullDatabaseSize: String? = null,
+  public val textIndexSize: String? = null,
+  public val onlineUsers: OnlineUsers? = null,
+  public val reportCalculatorThreads: Int? = null,
+  public val notificationAnalyzerThreads: Int? = null,
+)
+---
+/com/example/dto/TextCustomFieldActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class TextCustomFieldActivityItem(
+  public val id: String? = null,
+  public val target: Issue? = null,
+  public val removed: String? = null,
+  public val added: String? = null,
+  public val markup: String? = null,
+) : CustomFieldActivityItem()
+---
+/com/example/dto/TextFieldValue.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class TextFieldValue(
+  public val id: String? = null,
+  public val text: String? = null,
+  public val markdownText: String? = null,
+)
+---
+/com/example/dto/TextIssueCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class TextIssueCustomField(
+  public val id: String? = null,
+  public val `value`: TextFieldValue? = null,
+) : IssueCustomField()
+---
+/com/example/dto/TextMarkupActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class TextMarkupActivityItem(
+  public val id: String? = null,
+  public val removed: String? = null,
+  public val added: String? = null,
+  public val markup: String? = null,
+) : SimpleValueActivityItem()
+---
+/com/example/dto/TextProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class TextProjectCustomField(
+  public val id: String? = null,
+) : SimpleProjectCustomField()
+---
+/com/example/dto/TimeTrackingUserProfile.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class TimeTrackingUserProfile(
+  public val id: String? = null,
+  public val periodFormat: PeriodFieldFormat? = null,
+)
+---
+/com/example/dto/TimeZoneDescriptor.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class TimeZoneDescriptor(
+  public val id: String? = null,
+  public val presentation: String? = null,
+  public val offset: Int? = null,
+)
+---
+/com/example/dto/UnlimitedVisibility.kt
+package com.example.dto
+
+public object UnlimitedVisibility : Visibility()
+---
+/com/example/dto/UpsourceChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class UpsourceChangesProcessor(
+  public val id: String? = null,
+  public val server: UpsourceServer? = null,
+) : ChangesProcessor()
+---
+/com/example/dto/UpsourceServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class UpsourceServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsServer()
+---
+/com/example/dto/User.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class User(
+  public val id: String? = null,
+  public val login: String? = null,
+  public val fullName: String? = null,
+  public val email: String? = null,
+  public val jabberAccountName: String? = null,
+  public val ringId: String? = null,
+  public val guest: Boolean? = null,
+  public val online: Boolean? = null,
+  public val banned: Boolean? = null,
+  public val tags: List<IssueTag>? = null,
+  public val savedQueries: List<SavedQuery>? = null,
+  public val avatarUrl: String? = null,
+  public val profiles: UserProfiles? = null,
+)
+---
+/com/example/dto/UserBundle.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class UserBundle(
+  public val id: String? = null,
+  public val groups: List<UserGroup>? = null,
+  public val individuals: List<User>? = null,
+  public val aggregatedUsers: List<User>? = null,
+) : Bundle()
+---
+/com/example/dto/UserCustomFieldDefaults.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class UserCustomFieldDefaults(
+  public val id: String? = null,
+  public val bundle: UserBundle? = null,
+  public val defaultValues: List<User>? = null,
+) : CustomFieldDefaults()
+---
+/com/example/dto/UserGroup.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class UserGroup(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val ringId: String? = null,
+  public val usersCount: Long? = null,
+  public val icon: String? = null,
+  public val allUsersGroup: Boolean? = null,
+  public val teamForProject: Project? = null,
+)
+---
+/com/example/dto/UserProfiles.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class UserProfiles(
+  public val id: String? = null,
+  public val general: GeneralUserProfile? = null,
+  public val notifications: NotificationsUserProfile? = null,
+  public val timetracking: TimeTrackingUserProfile? = null,
+)
+---
+/com/example/dto/UserProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class UserProjectCustomField(
+  public val id: String? = null,
+  public val bundle: UserBundle? = null,
+  public val defaultValues: List<User>? = null,
+) : BundleProjectCustomField()
+---
+/com/example/dto/UsesMarkupActivityItem.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.String
+
+public data class UsesMarkupActivityItem(
+  public val id: String? = null,
+  public val removed: Boolean? = null,
+  public val added: Boolean? = null,
+  public val markup: String? = null,
+) : SimpleValueActivityItem()
+---
+/com/example/dto/VcsChange.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class VcsChange(
+  public val id: String? = null,
+  public val date: Long? = null,
+  public val fetched: Long? = null,
+  public val files: Int? = null,
+  public val author: User? = null,
+  public val processors: List<ChangesProcessor>? = null,
+  public val text: String? = null,
+  public val urls: List<String>? = null,
+  public val version: String? = null,
+  public val issue: Issue? = null,
+  public val state: Int? = null,
+)
+---
+/com/example/dto/VcsChangeActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class VcsChangeActivityItem(
+  public val id: String? = null,
+  public val removed: List<VcsChange>? = null,
+  public val added: List<VcsChange>? = null,
+  public val author: User? = null,
+) : CreatedDeletedActivityItem()
+---
+/com/example/dto/VcsHostingChangesProcessor.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class VcsHostingChangesProcessor(
+  public val id: String? = null,
+  public val server: VcsHostingServer? = null,
+  public val path: String? = null,
+  public val branchSpecification: String? = null,
+  public val committers: UserGroup? = null,
+) : ChangesProcessor()
+---
+/com/example/dto/VcsHostingServer.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class VcsHostingServer(
+  public val id: String? = null,
+  public val url: String? = null,
+) : VcsServer()
+---
+/com/example/dto/VcsServer.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class VcsServer(
+  public val id: String? = null,
+  public val url: String? = null,
+)
+---
+/com/example/dto/VcsUnresolvedUser.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class VcsUnresolvedUser(
+  public val id: String? = null,
+  public val name: String? = null,
+) : User()
+---
+/com/example/dto/VersionBundle.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class VersionBundle(
+  public val id: String? = null,
+  public val values: List<VersionBundleElement>? = null,
+) : BaseBundle()
+---
+/com/example/dto/VersionBundleCustomFieldDefaults.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class VersionBundleCustomFieldDefaults(
+  public val id: String? = null,
+  public val bundle: VersionBundle? = null,
+  public val defaultValues: List<VersionBundleElement>? = null,
+) : BundleCustomFieldDefaults()
+---
+/com/example/dto/VersionBundleElement.kt
+package com.example.dto
+
+import kotlin.Boolean
+import kotlin.Long
+import kotlin.String
+
+public data class VersionBundleElement(
+  public val id: String? = null,
+  public val archived: Boolean? = null,
+  public val releaseDate: Long? = null,
+  public val released: Boolean? = null,
+) : BundleElement()
+---
+/com/example/dto/VersionProjectCustomField.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class VersionProjectCustomField(
+  public val id: String? = null,
+  public val bundle: VersionBundle? = null,
+  public val defaultValues: List<VersionBundleElement>? = null,
+) : BundleProjectCustomField()
+---
+/com/example/dto/Visibility.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class Visibility(
+  public val id: String? = null,
+)
+---
+/com/example/dto/VisibilityActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class VisibilityActivityItem(
+  public val id: String? = null,
+  public val targetMember: String? = null,
+  public val targetSubMember: String? = null,
+) : MultiValueActivityItem()
+---
+/com/example/dto/VisibilityGroupActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class VisibilityGroupActivityItem(
+  public val id: String? = null,
+  public val targetMember: String? = null,
+  public val targetSubMember: String? = null,
+  public val removed: List<UserGroup>? = null,
+  public val added: List<UserGroup>? = null,
+) : VisibilityActivityItem()
+---
+/com/example/dto/VisibilityUserActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class VisibilityUserActivityItem(
+  public val id: String? = null,
+  public val targetMember: String? = null,
+  public val targetSubMember: String? = null,
+  public val removed: List<User>? = null,
+  public val added: List<User>? = null,
+) : VisibilityActivityItem()
+---
+/com/example/dto/VotersActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class VotersActivityItem(
+  public val id: String? = null,
+  public val target: Issue? = null,
+  public val removed: List<User>? = null,
+  public val added: List<User>? = null,
+) : MultiValueActivityItem()
+---
+/com/example/dto/WatchFolder.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class WatchFolder(
+  public val id: String? = null,
+  public val owner: User? = null,
+  public val visibleFor: UserGroup? = null,
+  public val updateableBy: UserGroup? = null,
+  public val readSharingSettings: WatchFolderSharingSettings? = null,
+  public val updateSharingSettings: WatchFolderSharingSettings? = null,
+) : IssueFolder()
+---
+/com/example/dto/WatchFolderSharingSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class WatchFolderSharingSettings(
+  public val id: String? = null,
+  public val permittedGroups: List<UserGroup>? = null,
+  public val permittedUsers: List<User>? = null,
+)
+---
+/com/example/dto/WIPLimit.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class WIPLimit(
+  public val id: String? = null,
+  public val max: Int? = null,
+  public val min: Int? = null,
+  public val column: AgileColumn? = null,
+)
+---
+/com/example/dto/WorkItemActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class WorkItemActivityItem(
+  public val id: String? = null,
+  public val target: IssueWorkItem? = null,
+  public val removed: List<IssueWorkItem>? = null,
+  public val added: List<IssueWorkItem>? = null,
+) : CreatedDeletedActivityItem()
+---
+/com/example/dto/WorkItemAttribute.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class WorkItemAttribute(
+  public val id: String? = null,
+  public val workItem: BaseWorkItem? = null,
+  public val projectAttribute: WorkItemProjectAttribute? = null,
+  public val `value`: WorkItemAttributeValue? = null,
+  public val name: String? = null,
+)
+---
+/com/example/dto/WorkItemAttributePrototype.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class WorkItemAttributePrototype(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val instances: WorkItemProjectAttribute? = null,
+  public val values: List<WorkItemAttributeValue>? = null,
+)
+---
+/com/example/dto/WorkItemAttributeValue.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class WorkItemAttributeValue(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val description: String? = null,
+  public val autoAttach: Boolean? = null,
+  public val prototype: WorkItemAttributePrototype? = null,
+)
+---
+/com/example/dto/WorkItemAuthorActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class WorkItemAuthorActivityItem(
+  public val id: String? = null,
+  public val target: IssueWorkItem? = null,
+  public val removed: User? = null,
+  public val added: User? = null,
+) : SingleValueActivityItem()
+---
+/com/example/dto/WorkItemDurationActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+
+public data class WorkItemDurationActivityItem(
+  public val id: String? = null,
+  public val target: IssueWorkItem? = null,
+  public val removed: DurationValue? = null,
+  public val added: DurationValue? = null,
+) : SingleValueActivityItem()
+---
+/com/example/dto/WorkItemProjectAttribute.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class WorkItemProjectAttribute(
+  public val id: String? = null,
+  public val timeTrackingSettings: ProjectTimeTrackingSettings? = null,
+  public val prototype: WorkItemAttributePrototype? = null,
+  public val values: List<WorkItemAttributeValue>? = null,
+  public val name: String? = null,
+  public val ordinal: Int? = null,
+)
+---
+/com/example/dto/WorkItemType.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Boolean
+import kotlin.String
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class WorkItemType(
+  public val id: String? = null,
+  public val name: String? = null,
+  public val autoAttached: Boolean? = null,
+)
+---
+/com/example/dto/WorkItemTypeActivityItem.kt
+package com.example.dto
+
+import kotlin.String
+import kotlin.collections.List
+
+public data class WorkItemTypeActivityItem(
+  public val id: String? = null,
+  public val target: IssueWorkItem? = null,
+  public val removed: List<WorkItemType>? = null,
+  public val added: List<WorkItemType>? = null,
+) : MultiValueActivityItem()
+---
+/com/example/dto/WorkTimeSettings.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public sealed class WorkTimeSettings(
+  public val id: String? = null,
+  public val minutesADay: Int? = null,
+  public val workDays: List<Int>? = null,
+  public val firstDayOfWeek: Int? = null,
+  public val daysAWeek: Int? = null,
+)

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusClientMultipart.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusClientMultipart.approved.txt
@@ -7,7 +7,7 @@
 ---
 /com/example/controller
 ---
-/com/example/controller/Controller.kt
+/com/example/controller/Client.kt
 package com.example.controller
 
 import com.example.dto.RunWorkflowRequest
@@ -22,7 +22,7 @@ import org.jboss.resteasy.reactive.multipart.FileUpload
 
 @Path("")
 @RegisterRestClient
-public interface Controller {
+public interface Client {
   /**
    * @return a Response whose entity is expected to be com.example.dto.RunWorkflowRequest
    */

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusClientMultipart.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusClientMultipart.approved.txt
@@ -1,0 +1,49 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.RunWorkflowRequest
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import org.jboss.resteasy.reactive.RestForm
+import org.jboss.resteasy.reactive.multipart.FileUpload
+
+@Path("")
+@RegisterRestClient
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be com.example.dto.RunWorkflowRequest
+   */
+  @POST
+  @Path("/api/v1/workflow-run")
+  @Produces("application/json")
+  @Consumes("multipart/form-data")
+  public fun runWorkflow(@RestForm("runWorkflowRequest") runWorkflowRequest: RunWorkflowRequest, @RestForm("config") config: FileUpload?): Response
+}
+---
+/com/example/dto
+---
+/com/example/dto/RunWorkflowRequest.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class RunWorkflowRequest(
+  public val inputConnection: String? = null,
+  public val outputConnection: String? = null,
+)

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusClientSample2.approved.txt
@@ -1,0 +1,326 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.PlayerActivitiesDTO
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.Response
+import kotlin.Int
+import kotlin.String
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+@Path("")
+@RegisterRestClient
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/activity")
+  @Consumes("application/json")
+  public fun syncPlayerActivities(request: PlayerActivitiesDTO?): Response
+
+  /**
+   * @return a Response whose entity is expected to be kotlin.String?
+   */
+  @GET
+  @Path("/api/v1/hello")
+  @Produces("*/*")
+  public fun hello(): Response
+
+  /**
+   * @return a Response whose entity is expected to be kotlin.String?
+   */
+  @GET
+  @Path("/api/v1/hello/{id}")
+  @Produces("*/*")
+  public fun hello(
+    @PathParam("id") id: Int?,
+    @QueryParam("foo") foo: String?,
+    @QueryParam("bar") bar: Int?,
+    @HeaderParam("baz") baz: String?,
+  ): Response
+}
+---
+/com/example/controller/PlayerController.kt
+package com.example.controller
+
+import com.example.dto.PlayersDTO
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+@Path("")
+@RegisterRestClient
+public interface PlayerController {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/players")
+  @Consumes("application/json")
+  public fun syncPlayers(request: PlayersDTO?): Response
+}
+---
+/com/example/dto
+---
+/com/example/dto/Car.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Car(
+  public val carProperty: String? = null,
+) : Vehicle()
+---
+/com/example/dto/DepositDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.ZonedDateTime
+import kotlin.Long
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class DepositDTO(
+  public val player: PlayerDTO,
+  public val playerenum: PlayerEnum? = null,
+  public val depositId: String? = null,
+  public val amountCents: Long? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val processedAt: ZonedDateTime? = null,
+)
+---
+/com/example/dto/Parent.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Parent(
+  public val vehicle: Vehicle,
+)
+---
+/com/example/dto/PlayerActivitiesDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.ZonedDateTime
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerActivitiesDTO(
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val from: ZonedDateTime? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val to: ZonedDateTime? = null,
+  public val items: List<PlayerActivityDTO>? = null,
+)
+---
+/com/example/dto/PlayerActivityDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerActivityDTO(
+  public val tag: String? = null,
+  public val userId: String? = null,
+  public val currency: String? = null,
+  public val betsSumCents: Long? = null,
+  public val wagerCents: Long? = null,
+  public val additionalDeductionsSumCents: Long? = null,
+  public val roundsCount: Long? = null,
+  public val bonusIssuesSumCents: Long? = null,
+  public val chargebacksSumCents: Long? = null,
+  public val chargebacksCount: Long? = null,
+  public val depositsSumCents: Long? = null,
+  public val depositsCount: Long? = null,
+  public val cashoutsSumCents: Long? = null,
+  public val cashoutsCount: Long? = null,
+  public val deposits: List<DepositDTO>? = null,
+)
+---
+/com/example/dto/PlayerDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import kotlin.Boolean
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerDTO(
+  public val tag: String? = null,
+  public val email: String? = null,
+  public val userId: String? = null,
+  public val dateOfBirth: LocalDate? = null,
+  public val firstName: String? = null,
+  public val lastName: String? = null,
+  public val nickname: String? = null,
+  public val gender: Gender? = null,
+  public val country: String? = null,
+  public val language: String? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val signUpAt: ZonedDateTime? = null,
+  public val duplicate: Boolean? = null,
+) {
+  public enum class Gender {
+    @JsonProperty("m")
+    M,
+    @JsonProperty("f")
+    F,
+    @JsonProperty("n")
+    N,
+  }
+}
+---
+/com/example/dto/PlayerEnum.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+
+public enum class PlayerEnum {
+  @JsonProperty("good")
+  GOOD,
+  @JsonProperty("bad")
+  BAD,
+  @JsonProperty("ugly")
+  UGLY,
+}
+---
+/com/example/dto/PlayersDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayersDTO(
+  public val players: List<PlayerDTO>? = null,
+)
+---
+/com/example/dto/Truck.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Truck(
+  public val truckProperty: String? = null,
+) : Vehicle()
+---
+/com/example/dto/Vehicle.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "vehicle_type",
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(value = Car::class, name = "CAR"),
+  JsonSubTypes.Type(value = Truck::class, name = "TRUCK"),
+)
+public sealed class Vehicle()
+---
+/com/example/dto/ZonedDateTimeDeserializer.kt
+package com.example.dto
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import java.time.DateTimeException
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+public class ZonedDateTimeDeserializer : JsonDeserializer<ZonedDateTime>() {
+  private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+  public override fun deserialize(jsonParser: JsonParser, deserializationContext: DeserializationContext): ZonedDateTime {
+    val date = jsonParser.text
+    try  {
+      return ZonedDateTime.parse(date, formatter)
+    }
+    catch (e: DateTimeException) {
+      try  {
+        return ZonedDateTime.parse(date + "Z", formatter)
+      }
+      catch (_: DateTimeException) {
+        // do nothing, exception thrown below
+      }
+      throw JsonParseException(jsonParser, e.message)
+    }
+  }
+}
+---
+/com/example/dto/ZonedDateTimeSerializer.kt
+package com.example.dto
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+public class ZonedDateTimeSerializer : JsonSerializer<ZonedDateTime>() {
+  private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+  public override fun serialize(
+    `value`: ZonedDateTime,
+    gen: JsonGenerator,
+    serializers: SerializerProvider,
+  ) {
+    gen.writeString(formatter.format(value))
+  }
+}

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusClientSample2.approved.txt
@@ -7,7 +7,7 @@
 ---
 /com/example/controller
 ---
-/com/example/controller/Controller.kt
+/com/example/controller/Client.kt
 package com.example.controller
 
 import com.example.dto.PlayerActivitiesDTO
@@ -26,7 +26,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 
 @Path("")
 @RegisterRestClient
-public interface Controller {
+public interface Client {
   /**
    * @return a Response whose entity is expected to be empty (no body)
    */
@@ -57,7 +57,7 @@ public interface Controller {
   ): Response
 }
 ---
-/com/example/controller/PlayerController.kt
+/com/example/controller/PlayerClient.kt
 package com.example.controller
 
 import com.example.dto.PlayersDTO
@@ -69,7 +69,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 
 @Path("")
 @RegisterRestClient
-public interface PlayerController {
+public interface PlayerClient {
   /**
    * @return a Response whose entity is expected to be empty (no body)
    */

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusDoNotGenerateResponseParameter.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusDoNotGenerateResponseParameter.approved.txt
@@ -1,0 +1,48 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.ToveDTO
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PUT
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import kotlin.Int
+
+@Path("")
+public interface Controller {
+  @GET
+  @Path("/api/v1/tove/{id}")
+  @Produces("application/json")
+  public fun getTove(@PathParam("id") id: Int?): ToveDTO?
+
+  @PUT
+  @Path("/api/v1/tove/{id}")
+  @Produces("application/json")
+  @Consumes("application/json")
+  public fun updateTove(request: ToveDTO?, @PathParam("id") id: Int?): ToveDTO?
+}
+---
+/com/example/dto
+---
+/com/example/dto/ToveDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class ToveDTO(
+  public val name: String? = null,
+)

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusGenerateSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusGenerateSample2.approved.txt
@@ -1,0 +1,324 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.PlayerActivitiesDTO
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.core.Context
+import jakarta.ws.rs.core.Response
+import kotlin.Int
+import kotlin.String
+
+@Path("")
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/activity")
+  @Consumes("application/json")
+  public fun syncPlayerActivities(request: PlayerActivitiesDTO?): Response
+
+  /**
+   * @return a Response whose entity is expected to be kotlin.String?
+   */
+  @GET
+  @Path("/api/v1/hello")
+  @Produces("*/*")
+  public fun hello(@Context requestContext: ContainerRequestContext): Response
+
+  /**
+   * @return a Response whose entity is expected to be kotlin.String?
+   */
+  @GET
+  @Path("/api/v1/hello/{id}")
+  @Produces("*/*")
+  public fun hello(
+    @PathParam("id") id: Int?,
+    @QueryParam("foo") foo: String?,
+    @QueryParam("bar") bar: Int?,
+    @HeaderParam("baz") baz: String?,
+  ): Response
+}
+---
+/com/example/controller/PlayerController.kt
+package com.example.controller
+
+import com.example.dto.PlayersDTO
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+
+@Path("")
+public interface PlayerController {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/players")
+  @Consumes("application/json")
+  public fun syncPlayers(request: PlayersDTO?): Response
+}
+---
+/com/example/dto
+---
+/com/example/dto/Car.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Car(
+  public val carProperty: String? = null,
+) : Vehicle()
+---
+/com/example/dto/DepositDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.ZonedDateTime
+import kotlin.Long
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class DepositDTO(
+  public val player: PlayerDTO,
+  public val playerenum: PlayerEnum? = null,
+  public val depositId: String? = null,
+  public val amountCents: Long? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val processedAt: ZonedDateTime? = null,
+)
+---
+/com/example/dto/Parent.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Parent(
+  public val vehicle: Vehicle,
+)
+---
+/com/example/dto/PlayerActivitiesDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.ZonedDateTime
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerActivitiesDTO(
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val from: ZonedDateTime? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val to: ZonedDateTime? = null,
+  public val items: List<PlayerActivityDTO>? = null,
+)
+---
+/com/example/dto/PlayerActivityDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerActivityDTO(
+  public val tag: String? = null,
+  public val userId: String? = null,
+  public val currency: String? = null,
+  public val betsSumCents: Long? = null,
+  public val wagerCents: Long? = null,
+  public val additionalDeductionsSumCents: Long? = null,
+  public val roundsCount: Long? = null,
+  public val bonusIssuesSumCents: Long? = null,
+  public val chargebacksSumCents: Long? = null,
+  public val chargebacksCount: Long? = null,
+  public val depositsSumCents: Long? = null,
+  public val depositsCount: Long? = null,
+  public val cashoutsSumCents: Long? = null,
+  public val cashoutsCount: Long? = null,
+  public val deposits: List<DepositDTO>? = null,
+)
+---
+/com/example/dto/PlayerDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import kotlin.Boolean
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerDTO(
+  public val tag: String? = null,
+  public val email: String? = null,
+  public val userId: String? = null,
+  public val dateOfBirth: LocalDate? = null,
+  public val firstName: String? = null,
+  public val lastName: String? = null,
+  public val nickname: String? = null,
+  public val gender: Gender? = null,
+  public val country: String? = null,
+  public val language: String? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val signUpAt: ZonedDateTime? = null,
+  public val duplicate: Boolean? = null,
+) {
+  public enum class Gender {
+    @JsonProperty("m")
+    M,
+    @JsonProperty("f")
+    F,
+    @JsonProperty("n")
+    N,
+  }
+}
+---
+/com/example/dto/PlayerEnum.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+
+public enum class PlayerEnum {
+  @JsonProperty("good")
+  GOOD,
+  @JsonProperty("bad")
+  BAD,
+  @JsonProperty("ugly")
+  UGLY,
+}
+---
+/com/example/dto/PlayersDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayersDTO(
+  public val players: List<PlayerDTO>? = null,
+)
+---
+/com/example/dto/Truck.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Truck(
+  public val truckProperty: String? = null,
+) : Vehicle()
+---
+/com/example/dto/Vehicle.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "vehicle_type",
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(value = Car::class, name = "CAR"),
+  JsonSubTypes.Type(value = Truck::class, name = "TRUCK"),
+)
+public sealed class Vehicle()
+---
+/com/example/dto/ZonedDateTimeDeserializer.kt
+package com.example.dto
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import java.time.DateTimeException
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+public class ZonedDateTimeDeserializer : JsonDeserializer<ZonedDateTime>() {
+  private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+  public override fun deserialize(jsonParser: JsonParser, deserializationContext: DeserializationContext): ZonedDateTime {
+    val date = jsonParser.text
+    try  {
+      return ZonedDateTime.parse(date, formatter)
+    }
+    catch (e: DateTimeException) {
+      try  {
+        return ZonedDateTime.parse(date + "Z", formatter)
+      }
+      catch (_: DateTimeException) {
+        // do nothing, exception thrown below
+      }
+      throw JsonParseException(jsonParser, e.message)
+    }
+  }
+}
+---
+/com/example/dto/ZonedDateTimeSerializer.kt
+package com.example.dto
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+public class ZonedDateTimeSerializer : JsonSerializer<ZonedDateTime>() {
+  private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+  public override fun serialize(
+    `value`: ZonedDateTime,
+    gen: JsonGenerator,
+    serializers: SerializerProvider,
+  ) {
+    gen.writeString(formatter.format(value))
+  }
+}

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusMultipart.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusMultipart.approved.txt
@@ -17,7 +17,7 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.Response
 import org.jboss.resteasy.reactive.RestForm
-import org.springframework.web.multipart.MultipartFile
+import org.jboss.resteasy.reactive.multipart.FileUpload
 
 @Path("")
 public interface Controller {
@@ -28,7 +28,7 @@ public interface Controller {
   @Path("/api/v1/workflow-run")
   @Produces("application/json")
   @Consumes("multipart/form-data")
-  public fun runWorkflow(@RestForm("runWorkflowRequest") runWorkflowRequest: RunWorkflowRequest, @RestForm("config") config: MultipartFile?): Response
+  public fun runWorkflow(@RestForm("runWorkflowRequest") runWorkflowRequest: RunWorkflowRequest, @RestForm("config") config: FileUpload?): Response
 }
 ---
 /com/example/dto

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusMultipart.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusMultipart.approved.txt
@@ -1,0 +1,47 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.RunWorkflowRequest
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.Response
+import org.jboss.resteasy.reactive.RestForm
+import org.springframework.web.multipart.MultipartFile
+
+@Path("")
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be com.example.dto.RunWorkflowRequest
+   */
+  @POST
+  @Path("/api/v1/workflow-run")
+  @Produces("application/json")
+  @Consumes("multipart/form-data")
+  public fun runWorkflow(@RestForm("runWorkflowRequest") runWorkflowRequest: RunWorkflowRequest, @RestForm("config") config: MultipartFile?): Response
+}
+---
+/com/example/dto
+---
+/com/example/dto/RunWorkflowRequest.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class RunWorkflowRequest(
+  public val inputConnection: String? = null,
+  public val outputConnection: String? = null,
+)

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusServerAndClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.quarkusServerAndClientSample2.approved.txt
@@ -11,51 +11,142 @@
 package com.example.controller
 
 import com.example.dto.PlayerActivitiesDTO
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.Response
 import kotlin.Int
 import kotlin.String
-import kotlin.Unit
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.`annotation`.PathVariable
-import org.springframework.web.bind.`annotation`.RequestBody
-import org.springframework.web.bind.`annotation`.RequestHeader
-import org.springframework.web.bind.`annotation`.RequestParam
-import org.springframework.web.service.`annotation`.GetExchange
-import org.springframework.web.service.`annotation`.PostExchange
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 
+@Path("")
+@RegisterRestClient
 public interface Client {
-  @PostExchange(value = "/api/v1/activity")
-  public fun syncPlayerActivities(@RequestBody request: PlayerActivitiesDTO?): ResponseEntity<Unit>
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/activity")
+  @Consumes("application/json")
+  public fun syncPlayerActivities(request: PlayerActivitiesDTO?): Response
 
-  @GetExchange(
-    value = "/api/v1/hello",
-    accept = ["*/*"],
-  )
-  public fun hello(): ResponseEntity<String>
+  /**
+   * @return a Response whose entity is expected to be kotlin.String?
+   */
+  @GET
+  @Path("/api/v1/hello")
+  @Produces("*/*")
+  public fun hello(): Response
 
-  @GetExchange(
-    value = "/api/v1/hello/{id}",
-    accept = ["*/*"],
-  )
+  /**
+   * @return a Response whose entity is expected to be kotlin.String?
+   */
+  @GET
+  @Path("/api/v1/hello/{id}")
+  @Produces("*/*")
   public fun hello(
-    @PathVariable(name = "id") id: Int?,
-    @RequestParam(required = false, name = "foo") foo: String?,
-    @RequestParam(required = true, name = "bar") bar: Int?,
-    @RequestHeader(required = true, name = "baz") baz: String?,
-  ): ResponseEntity<String>
+    @PathParam("id") id: Int?,
+    @QueryParam("foo") foo: String?,
+    @QueryParam("bar") bar: Int?,
+    @HeaderParam("baz") baz: String?,
+  ): Response
+}
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.PlayerActivitiesDTO
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.core.Context
+import jakarta.ws.rs.core.Response
+import kotlin.Int
+import kotlin.String
+
+@Path("")
+public interface Controller {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/activity")
+  @Consumes("application/json")
+  public fun syncPlayerActivities(request: PlayerActivitiesDTO?): Response
+
+  /**
+   * @return a Response whose entity is expected to be kotlin.String?
+   */
+  @GET
+  @Path("/api/v1/hello")
+  @Produces("*/*")
+  public fun hello(@Context requestContext: ContainerRequestContext): Response
+
+  /**
+   * @return a Response whose entity is expected to be kotlin.String?
+   */
+  @GET
+  @Path("/api/v1/hello/{id}")
+  @Produces("*/*")
+  public fun hello(
+    @PathParam("id") id: Int?,
+    @QueryParam("foo") foo: String?,
+    @QueryParam("bar") bar: Int?,
+    @HeaderParam("baz") baz: String?,
+  ): Response
 }
 ---
 /com/example/controller/PlayerClient.kt
 package com.example.controller
 
 import com.example.dto.PlayersDTO
-import kotlin.Unit
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.`annotation`.RequestBody
-import org.springframework.web.service.`annotation`.PostExchange
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 
+@Path("")
+@RegisterRestClient
 public interface PlayerClient {
-  @PostExchange(value = "/api/v1/players")
-  public fun syncPlayers(@RequestBody request: PlayersDTO?): ResponseEntity<Unit>
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/players")
+  @Consumes("application/json")
+  public fun syncPlayers(request: PlayersDTO?): Response
+}
+---
+/com/example/controller/PlayerController.kt
+package com.example.controller
+
+import com.example.dto.PlayersDTO
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+
+@Path("")
+public interface PlayerController {
+  /**
+   * @return a Response whose entity is expected to be empty (no body)
+   */
+  @POST
+  @Path("/api/v1/players")
+  @Consumes("application/json")
+  public fun syncPlayers(request: PlayersDTO?): Response
 }
 ---
 /com/example/dto

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.springAllRolesSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.springAllRolesSample2.approved.txt
@@ -7,6 +7,41 @@
 ---
 /com/example/controller
 ---
+/com/example/controller/Api.kt
+package com.example.controller
+
+import com.example.dto.PlayerActivitiesDTO
+import kotlin.Int
+import kotlin.String
+import org.springframework.web.bind.`annotation`.GetMapping
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.PostMapping
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+
+public interface Api {
+  @PostMapping(value = ["/api/v1/activity"])
+  public fun syncPlayerActivities(@RequestBody request: PlayerActivitiesDTO?)
+
+  @GetMapping(
+    value = ["/api/v1/hello"],
+    produces = ["*/*"],
+  )
+  public fun hello(): String?
+
+  @GetMapping(
+    value = ["/api/v1/hello/{id}"],
+    produces = ["*/*"],
+  )
+  public fun hello(
+    @PathVariable(name = "id") id: Int?,
+    @RequestParam(required = false, name = "foo") foo: String?,
+    @RequestParam(required = true, name = "bar") bar: Int?,
+    @RequestHeader(required = true, name = "baz") baz: String?,
+  ): String?
+}
+---
 /com/example/controller/Client.kt
 package com.example.controller
 
@@ -44,6 +79,56 @@ public interface Client {
   ): ResponseEntity<String>
 }
 ---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.PlayerActivitiesDTO
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kotlin.Int
+import kotlin.String
+import org.springframework.web.bind.`annotation`.GetMapping
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.PostMapping
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+
+public interface Controller {
+  @PostMapping(value = ["/api/v1/activity"])
+  public fun syncPlayerActivities(@RequestBody request: PlayerActivitiesDTO?, response: HttpServletResponse)
+
+  @GetMapping(
+    value = ["/api/v1/hello"],
+    produces = ["*/*"],
+  )
+  public fun hello(request: HttpServletRequest, response: HttpServletResponse): String?
+
+  @GetMapping(
+    value = ["/api/v1/hello/{id}"],
+    produces = ["*/*"],
+  )
+  public fun hello(
+    @PathVariable(name = "id") id: Int?,
+    @RequestParam(required = false, name = "foo") foo: String?,
+    @RequestParam(required = true, name = "bar") bar: Int?,
+    @RequestHeader(required = true, name = "baz") baz: String?,
+    response: HttpServletResponse,
+  ): String?
+}
+---
+/com/example/controller/PlayerApi.kt
+package com.example.controller
+
+import com.example.dto.PlayersDTO
+import org.springframework.web.bind.`annotation`.PostMapping
+import org.springframework.web.bind.`annotation`.RequestBody
+
+public interface PlayerApi {
+  @PostMapping(value = ["/api/v1/players"])
+  public fun syncPlayers(@RequestBody request: PlayersDTO?)
+}
+---
 /com/example/controller/PlayerClient.kt
 package com.example.controller
 
@@ -56,6 +141,19 @@ import org.springframework.web.service.`annotation`.PostExchange
 public interface PlayerClient {
   @PostExchange(value = "/api/v1/players")
   public fun syncPlayers(@RequestBody request: PlayersDTO?): ResponseEntity<Unit>
+}
+---
+/com/example/controller/PlayerController.kt
+package com.example.controller
+
+import com.example.dto.PlayersDTO
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.bind.`annotation`.PostMapping
+import org.springframework.web.bind.`annotation`.RequestBody
+
+public interface PlayerController {
+  @PostMapping(value = ["/api/v1/players"])
+  public fun syncPlayers(@RequestBody request: PlayersDTO?, response: HttpServletResponse)
 }
 ---
 /com/example/dto

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.springClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.springClientSample2.approved.txt
@@ -1,0 +1,305 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import com.example.dto.PlayerActivitiesDTO
+import kotlin.Int
+import kotlin.String
+import kotlin.Unit
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.GetExchange
+import org.springframework.web.service.`annotation`.PostExchange
+
+public interface Controller {
+  @PostExchange(value = "/api/v1/activity")
+  public fun syncPlayerActivities(@RequestBody request: PlayerActivitiesDTO?): ResponseEntity<Unit>
+
+  @GetExchange(
+    value = "/api/v1/hello",
+    accept = ["*/*"],
+  )
+  public fun hello(): ResponseEntity<String>
+
+  @GetExchange(
+    value = "/api/v1/hello/{id}",
+    accept = ["*/*"],
+  )
+  public fun hello(
+    @PathVariable(name = "id") id: Int?,
+    @RequestParam(required = false, name = "foo") foo: String?,
+    @RequestParam(required = true, name = "bar") bar: Int?,
+    @RequestHeader(required = true, name = "baz") baz: String?,
+  ): ResponseEntity<String>
+}
+---
+/com/example/controller/PlayerController.kt
+package com.example.controller
+
+import com.example.dto.PlayersDTO
+import kotlin.Unit
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.`annotation`.RequestBody
+import org.springframework.web.service.`annotation`.PostExchange
+
+public interface PlayerController {
+  @PostExchange(value = "/api/v1/players")
+  public fun syncPlayers(@RequestBody request: PlayersDTO?): ResponseEntity<Unit>
+}
+---
+/com/example/dto
+---
+/com/example/dto/Car.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Car(
+  public val carProperty: String? = null,
+) : Vehicle()
+---
+/com/example/dto/DepositDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.ZonedDateTime
+import kotlin.Long
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class DepositDTO(
+  public val player: PlayerDTO,
+  public val playerenum: PlayerEnum? = null,
+  public val depositId: String? = null,
+  public val amountCents: Long? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val processedAt: ZonedDateTime? = null,
+)
+---
+/com/example/dto/Parent.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Parent(
+  public val vehicle: Vehicle,
+)
+---
+/com/example/dto/PlayerActivitiesDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.ZonedDateTime
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerActivitiesDTO(
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val from: ZonedDateTime? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val to: ZonedDateTime? = null,
+  public val items: List<PlayerActivityDTO>? = null,
+)
+---
+/com/example/dto/PlayerActivityDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerActivityDTO(
+  public val tag: String? = null,
+  public val userId: String? = null,
+  public val currency: String? = null,
+  public val betsSumCents: Long? = null,
+  public val wagerCents: Long? = null,
+  public val additionalDeductionsSumCents: Long? = null,
+  public val roundsCount: Long? = null,
+  public val bonusIssuesSumCents: Long? = null,
+  public val chargebacksSumCents: Long? = null,
+  public val chargebacksCount: Long? = null,
+  public val depositsSumCents: Long? = null,
+  public val depositsCount: Long? = null,
+  public val cashoutsSumCents: Long? = null,
+  public val cashoutsCount: Long? = null,
+  public val deposits: List<DepositDTO>? = null,
+)
+---
+/com/example/dto/PlayerDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import kotlin.Boolean
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayerDTO(
+  public val tag: String? = null,
+  public val email: String? = null,
+  public val userId: String? = null,
+  public val dateOfBirth: LocalDate? = null,
+  public val firstName: String? = null,
+  public val lastName: String? = null,
+  public val nickname: String? = null,
+  public val gender: Gender? = null,
+  public val country: String? = null,
+  public val language: String? = null,
+  @field:JsonDeserialize(using = ZonedDateTimeDeserializer::class)
+  @get:JsonSerialize(using = ZonedDateTimeSerializer::class)
+  public val signUpAt: ZonedDateTime? = null,
+  public val duplicate: Boolean? = null,
+) {
+  public enum class Gender {
+    @JsonProperty("m")
+    M,
+    @JsonProperty("f")
+    F,
+    @JsonProperty("n")
+    N,
+  }
+}
+---
+/com/example/dto/PlayerEnum.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+
+public enum class PlayerEnum {
+  @JsonProperty("good")
+  GOOD,
+  @JsonProperty("bad")
+  BAD,
+  @JsonProperty("ugly")
+  UGLY,
+}
+---
+/com/example/dto/PlayersDTO.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.collections.List
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class PlayersDTO(
+  public val players: List<PlayerDTO>? = null,
+)
+---
+/com/example/dto/Truck.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Truck(
+  public val truckProperty: String? = null,
+) : Vehicle()
+---
+/com/example/dto/Vehicle.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "vehicle_type",
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(value = Car::class, name = "CAR"),
+  JsonSubTypes.Type(value = Truck::class, name = "TRUCK"),
+)
+public sealed class Vehicle()
+---
+/com/example/dto/ZonedDateTimeDeserializer.kt
+package com.example.dto
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import java.time.DateTimeException
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+public class ZonedDateTimeDeserializer : JsonDeserializer<ZonedDateTime>() {
+  private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+  public override fun deserialize(jsonParser: JsonParser, deserializationContext: DeserializationContext): ZonedDateTime {
+    val date = jsonParser.text
+    try  {
+      return ZonedDateTime.parse(date, formatter)
+    }
+    catch (e: DateTimeException) {
+      try  {
+        return ZonedDateTime.parse(date + "Z", formatter)
+      }
+      catch (_: DateTimeException) {
+        // do nothing, exception thrown below
+      }
+      throw JsonParseException(jsonParser, e.message)
+    }
+  }
+}
+---
+/com/example/dto/ZonedDateTimeSerializer.kt
+package com.example.dto
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+public class ZonedDateTimeSerializer : JsonSerializer<ZonedDateTime>() {
+  private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+  public override fun serialize(
+    `value`: ZonedDateTime,
+    gen: JsonGenerator,
+    serializers: SerializerProvider,
+  ) {
+    gen.writeString(formatter.format(value))
+  }
+}

--- a/src/test/java/ru/curs/hurdygurdy/KotlinUsageTest.kt
+++ b/src/test/java/ru/curs/hurdygurdy/KotlinUsageTest.kt
@@ -1,0 +1,39 @@
+package ru.curs.hurdygurdy
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Mirrors the README's Kotlin usage example (e.g. Gradle's buildSrc),
+ * verifying that the two-axis configuration (framework x generate) is
+ * usable from Kotlin.
+ */
+class KotlinUsageTest {
+    @TempDir
+    lateinit var result: Path
+
+    @Test
+    fun readmeKotlinUsageExample() {
+        val codegen = KotlinCodegen(
+            GeneratorParams.rootPackage("com.example.project")
+                .framework(Framework.QUARKUS)
+                .generate(Role.CONTROLLER, Role.CLIENT)
+        )
+        codegen.generate(Path.of("src/test/resources/sample2.yaml"), result)
+
+        val controllerPackage = result.resolve("com/example/project/controller")
+        assertTrue(Files.exists(controllerPackage.resolve("PlayerController.kt")))
+        assertTrue(Files.exists(controllerPackage.resolve("PlayerClient.kt")))
+    }
+
+    @Test
+    fun rolesCanBePassedAsKotlinCollection() {
+        val params = GeneratorParams.rootPackage("com.example.project")
+            .generate(listOf(Role.CONTROLLER, Role.API))
+        assertEquals(setOf(Role.CONTROLLER, Role.API), params.getGenerate())
+    }
+}


### PR DESCRIPTION
## What

Adds **framework** and **role** selectors to code generation so hurdy-gurdy can emit more than Spring server interfaces:

| Framework | Role | Output |
|-----------|------|--------|
| Spring (default) | Server (default) | Existing Spring MVC controller interface |
| Spring | Client | Spring HTTP Interface (`@GetExchange`/`@PostExchange`, `ResponseEntity`) |
| Quarkus | Server | JAX-RS interface (`@Path`, `@GET`, `@PathParam`, `RestForm` multipart, `ContainerRequestContext`) |
| Quarkus | Client | JAX-RS interface + `@RegisterRestClient` |

Both Java and Kotlin generators are covered.

## Details

- `GeneratorParams` gains `framework(...)` (default `SPRING`) and `role(...)` (default `SERVER`) — fully backward compatible, existing callers unchanged.
- Quarkus server: binary multipart parts map to `FileUpload`; `@Produces`/`@Consumes` emitted conditionally; `x-include-request` supported via `ContainerRequestContext`.
- Docs updated for both selectors.
- Rebased on current `master` (includes #516 illegal-param-name / inheritance fixes).

## Tests

`mvn test` — 104/104 pass (new approved-snapshot tests for each framework/role combination).

## Disclosure

Prepared with AI assistance (Claude Code): rebase conflict resolution and this PR description. Code reviewed by the author.
