### PR TITLE
Add CLI (fat jar + native binary) and GitHub Releases pipeline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Publish core to the isolated repo
         run: |
           CORE_JAR=$(find target -maxdepth 1 -name 'hurdy-gurdy-*.jar' \
-            ! -name '*-sources.jar' ! -name '*-javadoc.jar')
+            ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-cli.jar')
           mvn -B install:install-file \
             -Dfile="$CORE_JAR" \
             -DpomFile=pom.xml \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '25'
+          distribution: 'liberica'
+          java-version: '21'
       - name: Build fat jar
         run: mvn -B clean -DskipTests package
       - name: Stage jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: release
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: hurdy-gurdy-linux-x64
+            bin: hurdy-gurdy
+          - os: macos-latest
+            asset: hurdy-gurdy-macos-arm64
+            bin: hurdy-gurdy
+          - os: windows-latest
+            asset: hurdy-gurdy-windows-x64.exe
+            bin: hurdy-gurdy.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          distribution: 'liberica'
+          java-version: '25'
+          github-token: ${{ github.token }}
+      - name: Build native image
+        run: mvn -B clean -Pnative -DskipTests package
+      - name: Smoke test binary
+        shell: bash
+        run: ./target/${{ matrix.bin }} --version
+      - name: Rename binary
+        shell: bash
+        run: mv target/${{ matrix.bin }} ${{ matrix.asset }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+          if-no-files-found: error
+
+  jar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+      - name: Build fat jar
+        run: mvn -B clean -DskipTests package
+      - name: Stage jar
+        shell: bash
+        run: |
+          mkdir -p staging
+          cp target/hurdy-gurdy-*-cli.jar staging/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cli-jar
+          path: staging/hurdy-gurdy-*-cli.jar
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,37 @@ jobs:
           name: cli-jar
           path: staging/hurdy-gurdy-*-cli.jar
           if-no-files-found: error
+
+  publish:
+    needs: [native, jar]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: List downloaded assets
+        run: ls -R artifacts
+      - name: Reset rolling snapshot release
+        if: github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release delete snapshot --cleanup-tag --yes || true
+      - name: Publish rolling snapshot
+        if: github.ref == 'refs/heads/master'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: snapshot
+          name: Snapshot (latest master)
+          prerelease: true
+          body: "Rolling build from master @ ${{ github.sha }}"
+          files: artifacts/*
+      - name: Publish tagged release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          prerelease: false
+          files: artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
           distribution: 'liberica'
           java-version: '25'
           github-token: ${{ github.token }}
+      - name: Set release version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: mvn -B versions:set -DnewVersion="${GITHUB_REF_NAME#v}" -DgenerateBackupPoms=false
       - name: Build native image
         run: mvn -B clean -Pnative -DskipTests package
       - name: Smoke test binary
@@ -57,6 +61,10 @@ jobs:
         with:
           distribution: 'liberica'
           java-version: '21'
+      - name: Set release version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: mvn -B versions:set -DnewVersion="${GITHUB_REF_NAME#v}" -DgenerateBackupPoms=false
       - name: Build fat jar
         run: mvn -B clean -DskipTests package
       - name: Stage jar

--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ Files.createDirectories(resultPath)
 codegen.generate(yamlPath, resultPath)
 ```
 
+## Usage as a CLI
+
+Build the executable fat jar:
+
+    mvn -DskipTests package
+    java -jar target/hurdy-gurdy-<version>-cli.jar \
+        --spec src/main/openapi/api.yaml \
+        --root-package com.example.project \
+        --output generated-sources \
+        --framework spring --generate controller,client
+
+Options: `--language java|kotlin`, `--framework spring|quarkus`,
+`--generate` (subset of `controller,api,client`), `--response-parameter`,
+`--force-snake-case` (negate with `--no-...`). Run with `--help` for the full list.
+
+Optionally build a native binary (requires GraalVM):
+
+    mvn -Pnative -DskipTests package
+    ./target/hurdy-gurdy --spec ... --root-package ... --output ...
+
 ## Configuration parameters
 
 | Parameter name | Type | Default value | Description |

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,24 @@
     </dependencies>
 
     <build>
+        <resources>
+            <!-- Filter only the version file so ${project.version} is interpolated;
+                 copy everything else (incl. native-image JSON) verbatim. -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>hurdy-gurdy-version.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>hurdy-gurdy-version.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
             <version>1.13.0</version>
         </dependency>
         <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.7.7</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>kotlinpoet-jvm</artifactId>
             <version>2.3.0</version>
@@ -387,6 +393,16 @@
                 <configuration>
                     <release>${maven.compiler.release}</release>
                     <testRelease>21</testRelease>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>info.picocli</groupId>
+                            <artifactId>picocli-codegen</artifactId>
+                            <version>4.7.7</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <!-- "One goal to build them all": after the core/maven-plugin artifact is

--- a/pom.xml
+++ b/pom.xml
@@ -483,5 +483,34 @@
                 <gradlew.executable>${project.basedir}/gradle-plugin/gradlew</gradlew.executable>
             </properties>
         </profile>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>0.11.0</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>compile-no-fork</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <imageName>hurdy-gurdy</imageName>
+                            <mainClass>ru.curs.hurdygurdy.Main</mainClass>
+                            <metadataRepository>
+                                <enabled>true</enabled>
+                            </metadataRepository>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,30 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>cli-shade</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>cli</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>ru.curs.hurdygurdy.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>cli</shadedClassifierName>
                             <transformers>

--- a/src/main/java/ru/curs/hurdygurdy/Main.java
+++ b/src/main/java/ru/curs/hurdygurdy/Main.java
@@ -2,10 +2,13 @@ package ru.curs.hurdygurdy;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.IVersionProvider;
 import picocli.CommandLine.Option;
 
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -17,7 +20,7 @@ import java.util.concurrent.Callable;
 @Command(
         name = "hurdy-gurdy",
         mixinStandardHelpOptions = true,
-        version = "hurdy-gurdy 2.11-SNAPSHOT",
+        versionProvider = Main.VersionProvider.class,
         description = "Generate Java/Kotlin client & server code from an OpenAPI spec.")
 public final class Main implements Callable<Integer> {
 
@@ -88,5 +91,24 @@ public final class Main implements Callable<Integer> {
      */
     public static void main(String[] args) {
         System.exit(run(args));
+    }
+
+    /**
+     * Supplies the {@code --version} string from the build-filtered
+     * {@code hurdy-gurdy-version.properties} resource, so it always reflects
+     * the Maven project version instead of a hardcoded literal.
+     */
+    static final class VersionProvider implements IVersionProvider {
+        @Override
+        public String[] getVersion() throws Exception {
+            Properties props = new Properties();
+            try (InputStream in =
+                         Main.class.getResourceAsStream("/hurdy-gurdy-version.properties")) {
+                if (in != null) {
+                    props.load(in);
+                }
+            }
+            return new String[] {"hurdy-gurdy " + props.getProperty("version", "unknown")};
+        }
     }
 }

--- a/src/main/java/ru/curs/hurdygurdy/Main.java
+++ b/src/main/java/ru/curs/hurdygurdy/Main.java
@@ -1,0 +1,92 @@
+package ru.curs.hurdygurdy;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ * Command-line entrypoint for the hurdy-gurdy code generator. Mirrors the
+ * Maven {@code gen-server} goal: reads an OpenAPI spec and writes generated
+ * Java/Kotlin sources into an output directory.
+ */
+@Command(
+        name = "hurdy-gurdy",
+        mixinStandardHelpOptions = true,
+        version = "hurdy-gurdy 2.11-SNAPSHOT",
+        description = "Generate Java/Kotlin client & server code from an OpenAPI spec.")
+public final class Main implements Callable<Integer> {
+
+    @Option(names = {"-s", "--spec"}, required = true,
+            description = "OpenAPI spec file (YAML or JSON).")
+    private Path spec;
+
+    @Option(names = {"-p", "--root-package"}, required = true,
+            description = "Root package for generated code.")
+    private String rootPackage;
+
+    @Option(names = {"-o", "--output"}, required = true,
+            description = "Output directory (created if missing).")
+    private Path output;
+
+    @Option(names = {"-l", "--language"}, defaultValue = "java",
+            description = "Target language: java or kotlin (default: ${DEFAULT-VALUE}).")
+    private String language;
+
+    @Option(names = {"-f", "--framework"}, defaultValue = "spring",
+            description = "Target framework: spring or quarkus (default: ${DEFAULT-VALUE}).")
+    private String framework;
+
+    @Option(names = {"-g", "--generate"}, defaultValue = "controller",
+            description = "Comma-separated subset of controller,api,client "
+                    + "(default: ${DEFAULT-VALUE}).")
+    private String generate;
+
+    @Option(names = "--response-parameter", negatable = true, defaultValue = "false",
+            description = "Add HttpServletResponse parameter to controllers "
+                    + "(default: ${DEFAULT-VALUE}).")
+    private boolean responseParameter;
+
+    @Option(names = "--force-snake-case", negatable = true, defaultValue = "true",
+            description = "Force snake_case for properties (default: ${DEFAULT-VALUE}).")
+    private boolean forceSnakeCase;
+
+    @Override
+    public Integer call() throws Exception {
+        Set<Role> roles = Role.parse(generate);
+        GeneratorParams params = GeneratorParams.rootPackage(rootPackage)
+                .generateResponseParameter(responseParameter)
+                .forceSnakeCaseForProperties(forceSnakeCase)
+                .framework(Framework.of(framework))
+                .generate(roles);
+        Codegen<?> codegen = "java".equalsIgnoreCase(language)
+                ? new JavaCodegen(params)
+                : new KotlinCodegen(params);
+        Files.createDirectories(output);
+        codegen.generate(spec, output);
+        return 0;
+    }
+
+    /**
+     * Parses the given arguments and runs the generator.
+     *
+     * @param args command-line arguments
+     * @return process exit code (0 on success)
+     */
+    public static int run(String... args) {
+        return new CommandLine(new Main()).execute(args);
+    }
+
+    /**
+     * Command-line entrypoint.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(String[] args) {
+        System.exit(run(args));
+    }
+}

--- a/src/main/java/ru/curs/hurdygurdy/Main.java
+++ b/src/main/java/ru/curs/hurdygurdy/Main.java
@@ -54,16 +54,19 @@ public final class Main implements Callable<Integer> {
                     + "(default: ${DEFAULT-VALUE}).")
     private boolean responseParameter;
 
-    @Option(names = "--force-snake-case", negatable = true, defaultValue = "true",
-            description = "Force snake_case for properties (default: ${DEFAULT-VALUE}).")
-    private boolean forceSnakeCase;
+    // picocli negatable semantics assign `negated ? defaultValue : !defaultValue`,
+    // so defaultValue="true" inverts the flag (--no-force-snake-case would enable it).
+    // Use a nullable Boolean with no default instead: null means "on".
+    @Option(names = "--force-snake-case", negatable = true,
+            description = "Force snake_case for properties (default: true).")
+    private Boolean forceSnakeCase;
 
     @Override
     public Integer call() throws Exception {
         Set<Role> roles = Role.parse(generate);
         GeneratorParams params = GeneratorParams.rootPackage(rootPackage)
                 .generateResponseParameter(responseParameter)
-                .forceSnakeCaseForProperties(forceSnakeCase)
+                .forceSnakeCaseForProperties(forceSnakeCase == null || forceSnakeCase)
                 .framework(Framework.of(framework))
                 .generate(roles);
         Codegen<?> codegen = "java".equalsIgnoreCase(language)

--- a/src/main/resources/META-INF/native-image/ru.curs/hurdy-gurdy/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/ru.curs/hurdy-gurdy/reachability-metadata.json
@@ -1,0 +1,252 @@
+{
+  "reflection": [
+    {
+      "type": "com.fasterxml.jackson.databind.deser.BeanDeserializerModifier[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.deser.KeyDeserializers[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.deser.ValueInstantiators[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.ser.BeanSerializerModifier[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "type": "groovy.lang.Closure"
+    },
+    {
+      "type": "io.swagger.v3.parser.converter.SwaggerConverter"
+    },
+    {
+      "type": "java.beans.Introspector"
+    },
+    {
+      "type": "java.lang.Boolean",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getBoolean",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Class",
+      "methods": [
+        {
+          "name": "isRecord",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.ClassValue"
+    },
+    {
+      "type": "java.lang.Object"
+    },
+    {
+      "type": "java.nio.file.Path"
+    },
+    {
+      "type": "java.nio.file.Paths",
+      "methods": [
+        {
+          "name": "get",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.sql.Connection"
+    },
+    {
+      "type": "java.sql.Date"
+    },
+    {
+      "type": "java.sql.Driver"
+    },
+    {
+      "type": "java.sql.DriverManager"
+    },
+    {
+      "type": "java.sql.Time"
+    },
+    {
+      "type": "java.sql.Timestamp"
+    },
+    {
+      "type": "java.time.Duration"
+    },
+    {
+      "type": "java.time.Instant"
+    },
+    {
+      "type": "java.time.LocalDate"
+    },
+    {
+      "type": "java.time.LocalDateTime"
+    },
+    {
+      "type": "java.time.LocalTime"
+    },
+    {
+      "type": "java.time.MonthDay"
+    },
+    {
+      "type": "java.time.OffsetDateTime"
+    },
+    {
+      "type": "java.time.OffsetTime"
+    },
+    {
+      "type": "java.time.Period"
+    },
+    {
+      "type": "java.time.Year"
+    },
+    {
+      "type": "java.time.YearMonth"
+    },
+    {
+      "type": "java.time.ZoneId"
+    },
+    {
+      "type": "java.time.ZoneOffset"
+    },
+    {
+      "type": "java.time.ZonedDateTime"
+    },
+    {
+      "type": "kotlin.SafePublicationLazyImpl"
+    },
+    {
+      "type": "kotlin.jvm.internal.DefaultConstructorMarker"
+    },
+    {
+      "type": "kotlin.reflect.jvm.internal.ReflectionFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.yaml.snakeyaml.LoaderOptions",
+      "methods": [
+        {
+          "name": "setAllowDuplicateKeys",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setAllowRecursiveKeys",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setCodePointLimit",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setMaxAliasesForCollections",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "picocli.CommandLine$AutoHelpMixin",
+      "fields": [
+        {
+          "name": "helpRequested"
+        },
+        {
+          "name": "versionRequested"
+        }
+      ]
+    },
+    {
+      "type": "ru.curs.hurdygurdy.Main",
+      "fields": [
+        {
+          "name": "forceSnakeCase"
+        },
+        {
+          "name": "framework"
+        },
+        {
+          "name": "generate"
+        },
+        {
+          "name": "language"
+        },
+        {
+          "name": "output"
+        },
+        {
+          "name": "responseParameter"
+        },
+        {
+          "name": "rootPackage"
+        },
+        {
+          "name": "spec"
+        }
+      ]
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData"
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData_en"
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData_en_US"
+    },
+    {
+      "type": "sun.util.resources.cldr.CalendarData"
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/services/io.swagger.v3.parser.core.extensions.SwaggerParserExtension"
+    },
+    {
+      "glob": "META-INF/services/io.swagger.v3.parser.extensions.JsonSchemaParserExtension"
+    },
+    {
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/src/main/resources/META-INF/native-image/ru.curs/hurdy-gurdy/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/ru.curs/hurdy-gurdy/reachability-metadata.json
@@ -237,6 +237,9 @@
   ],
   "resources": [
     {
+      "glob": "hurdy-gurdy-version.properties"
+    },
+    {
       "glob": "META-INF/services/io.swagger.v3.parser.core.extensions.SwaggerParserExtension"
     },
     {

--- a/src/main/resources/hurdy-gurdy-version.properties
+++ b/src/main/resources/hurdy-gurdy-version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/src/test/java/ru/curs/hurdygurdy/MainTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/MainTest.java
@@ -1,0 +1,43 @@
+package ru.curs.hurdygurdy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MainTest {
+
+    @TempDir
+    Path out;
+
+    private long javaFilesIn(Path dir) throws IOException {
+        try (Stream<Path> walk = Files.walk(dir)) {
+            return walk.filter(p -> p.toString().endsWith(".java")).count();
+        }
+    }
+
+    @Test
+    void generatesJavaSourcesFromSpec() throws IOException {
+        int exit = Main.run(
+                "--spec", "src/test/resources/commonparam.yaml",
+                "--root-package", "com.example",
+                "--output", out.toString());
+
+        assertThat(exit).isEqualTo(0);
+        assertThat(javaFilesIn(out)).isGreaterThan(0);
+    }
+
+    @Test
+    void missingRequiredOptionFailsWithNonZeroExit() {
+        int exit = Main.run(
+                "--spec", "src/test/resources/commonparam.yaml",
+                "--output", out.toString());
+        // --root-package is required; picocli returns a non-zero usage exit code
+        assertThat(exit).isNotEqualTo(0);
+    }
+}

--- a/src/test/java/ru/curs/hurdygurdy/MainTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/MainTest.java
@@ -3,9 +3,14 @@ package ru.curs.hurdygurdy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +35,30 @@ class MainTest {
 
         assertThat(exit).isEqualTo(0);
         assertThat(javaFilesIn(out)).isGreaterThan(0);
+    }
+
+    @Test
+    void versionOptionReflectsPomVersion() throws IOException {
+        Properties props = new Properties();
+        try (InputStream in = getClass().getResourceAsStream("/hurdy-gurdy-version.properties")) {
+            assertThat(in).as("filtered version resource on classpath").isNotNull();
+            props.load(in);
+        }
+        String version = props.getProperty("version");
+        // Resource filtering actually ran (no unresolved Maven placeholder).
+        assertThat(version).isNotNull().doesNotContain("${");
+
+        PrintStream original = System.out;
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(buf, true, StandardCharsets.UTF_8));
+        int exit;
+        try {
+            exit = Main.run("--version");
+        } finally {
+            System.setOut(original);
+        }
+        assertThat(exit).isEqualTo(0);
+        assertThat(buf.toString(StandardCharsets.UTF_8)).contains("hurdy-gurdy " + version);
     }
 
     @Test


### PR DESCRIPTION
## What

Adds a command-line entrypoint to hurdy-gurdy, shipped as an executable fat jar and a GraalVM native binary, plus a CI pipeline that publishes both to GitHub Releases.

### CLI
- New `ru.curs.hurdygurdy.Main` — a picocli command mirroring the `gen-server` Mojo one-to-one (`--spec`, `--root-package`, `--output`, `--language`, `--framework`, `--generate`, `--[no-]response-parameter`, `--[no-]force-snake-case`, `--help`, `--version`).
- `picocli` is an `optional` compile dep (kept off the plugin artifact's transitive classpath); `picocli-codegen` runs as an annotation processor for compile-time validation + native-image config.
- `maven-shade-plugin` produces an **attached** `-cli` fat jar; the primary `maven-plugin` artifact and its POM are unchanged (`createDependencyReducedPom` disabled).

### Native binary
- Opt-in `-Pnative` profile (`native-maven-plugin`, reachability-metadata repo) + committed agent-captured `reachability-metadata.json`.
- Verified: native binary builds and passes all 112 `language × framework × generate × flag` generation combinations.

### Versioning
- `--version` is derived from a build-filtered resource via a picocli `IVersionProvider` (works in JVM and native), replacing the hardcoded literal.
- On `v*` tags, CI runs `mvn versions:set` so jar assets and `--version` reflect the real release version.

### CI (`.github/workflows/release.yml`)
- On `master` push → rolling `snapshot` pre-release; on `v*` tag → normal release.
- Native binaries for linux-x64 / macos-arm64 / windows-x64 (each smoke-tested with `--version` before upload) + the `cli.jar`.
- All-or-nothing publish. Existing `build.yml` and Maven Central publishing untouched.

## Testing
- 117/117 unit tests pass (incl. new `MainTest`).
- Fat jar runs + `--help`/`--version`; native binary built with Liberica NIK 25 and exercised across all generation combinations.
- `actionlint` clean on the workflow.

Note: the release workflow can only be verified end-to-end once merged and run on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkZZaH7875AuKxdm2wpNEM
