### PR TITLE
Fix invalid Gradle DSL in config generator

### DIFF
--- a/docs/generator.js
+++ b/docs/generator.js
@@ -39,6 +39,11 @@ const xmlEscape = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").
 // Quote a shell arg only when it contains whitespace (keeps clean paths unquoted).
 const shArg = (s) => (/\s/.test(s) ? `"${s}"` : s);
 
+// Name the Gradle spec block after the OpenAPI file: "petstore.yaml" -> "petstore".
+// Strips dir, query string, extension; falls back to "api" if nothing usable remains.
+const specBlockName = (p) =>
+  String(p).split(/[\\/]/).pop().replace(/\?.*$/, "").replace(/\.[^.]+$/, "") || "api";
+
 // The Java DTO style is Java-only (Kotlin always emits data classes) and lombok
 // is the default, so it's emitted only for a non-default Java style.
 const useDtoStyle = (c) => c.language === "java" && c.dtoStyle && c.dtoStyle !== "lombok";
@@ -104,7 +109,7 @@ function gradleSnippet(c) {
     `}`,
     ``,
     `hurdyGurdy {`,
-    `    api {`,
+    `    "${specBlockName(c.spec)}" {`,
     ...body,
     `    }`,
     `}`,

--- a/docs/test.js
+++ b/docs/test.js
@@ -48,12 +48,17 @@ const base = {
   const out = g.gradleSnippet(base);
   assert.ok(out.includes(`id("ru.curs.hurdy-gurdy") version "${g.VERSION}"`), "gradle plugin id+version");
   assert.ok(out.includes("hurdyGurdy {"), "gradle extension block");
-  assert.ok(out.includes("api {"), "gradle named block");
+  assert.ok(out.includes(`"api" {`), "gradle named block");
   assert.ok(out.includes(`spec = file("src/main/openapi/api.yaml")`), "gradle spec");
   assert.ok(out.includes(`rootPackage = "com.example.project"`), "gradle rootPackage");
   assert.ok(!out.includes("Framework"), "gradle omits default framework + import");
   assert.ok(!out.includes("Role"), "gradle omits default generate + import");
   assert.ok(!out.includes("Language"), "gradle omits default language + import");
+}
+// --- Gradle spec block named after the OpenAPI file ---
+{
+  assert.ok(g.gradleSnippet({ ...base, spec: "openapi/petstore.yaml" }).includes(`"petstore" {`), "gradle block from filename");
+  assert.ok(g.gradleSnippet({ ...base, spec: "billing.yml?ref=main" }).includes(`"billing" {`), "gradle block strips query+ext");
 }
 // --- Gradle non-defaults ---
 {


### PR DESCRIPTION
## Problem

The docs config generator emitted an unquoted `api { }` block for Gradle:

```kotlin
hurdyGurdy {
    api {
        spec = file("src/main/openapi/api.yaml")
        rootPackage = "com.example.project"
    }
}
```

`hurdyGurdy` is a `NamedDomainObjectContainer<GenerationSpec>`, so Kotlin DSL generates no type-safe accessor for a user-chosen spec name — `api { }` does not compile.

## Fix

- Emit the concise quoted form `"name" { }`, backed by the extension's `String.invoke` operator.
- Derive the block name from the OpenAPI filename (`openapi/petstore.yaml` → `"petstore"`) instead of hardcoding `api`. Strips dir, query string, extension; falls back to `"api"`.

```kotlin
hurdyGurdy {
    "petstore" {
        spec = file("openapi/petstore.yaml")
        rootPackage = "com.example.project"
    }
}
```

Generator tests updated + new cases for the derived name. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)