### PR TITLE
fix: instantiable fallback for subtype-less discriminator bases

### DIFF
--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -436,11 +436,17 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
         if (isPolymorphicInterface(schema)) {
             return buildSealedInterface(name, schema, openAPI, false);
         }
-        // 2) discriminator base -> sealed interface (name-based polymorphism)
-        if (schema.getDiscriminator() != null) {
+        // 2) discriminator base WITH subtypes -> sealed interface (name-based
+        // polymorphism). A discriminator base with NO subtypes would become a bare,
+        // uninstantiable interface, so let it fall through to the concrete-record
+        // path below and re-attach @JsonTypeInfo — mirroring the class DTO styles.
+        if (schema.getDiscriminator() != null && !permittedSubtypes(name, schema, openAPI).isEmpty()) {
             return buildSealedInterface(name, schema, openAPI, true);
         }
-        // 3) concrete schema -> record (flatten allOf-inherited components)
+        // 3) concrete schema -> record (flatten allOf-inherited components). A
+        // subtype-less discriminator base also lands here (buildConcreteRecord
+        // keeps its @JsonTypeInfo and drops the discriminator property), so it is
+        // instantiable instead of a bare interface.
         List<RecordComponent> inherited = inheritedComponents(schema, openAPI);
         List<ClassName> implemented = ancestorInterfaces(name, schema, openAPI);
         return buildConcreteRecord(name, currentSchemaOf(schema), openAPI, inherited, implemented);
@@ -593,6 +599,14 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
         if (params.isForceSnakeCaseForProperties()) {
             recordBuilder.addAnnotation(AnnotationSpec.builder(JsonNaming.class).addMember("value",
                     "$T.class", ClassName.get(PropertyNamingStrategies.SnakeCaseStrategy.class)).build());
+        }
+        // A subtype-less discriminator base is built as a concrete record (rather
+        // than a bare, uninstantiable interface); keep its @JsonTypeInfo so Jackson
+        // still reads/writes the type-id property. Bases WITH subtypes never reach
+        // here (they become sealed interfaces); concrete subtypes' ownSchema is the
+        // inline allOf member, whose discriminator is null, so they stay unannotated.
+        if (ownSchema.getDiscriminator() != null) {
+            recordBuilder.addAnnotation(discriminatorTypeInfo(ownSchema));
         }
         implemented.forEach(recordBuilder::addSuperinterface);
 

--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -350,9 +350,26 @@ class KotlinTypeDefiner internal constructor(
             )
         }
 
+        val subclassMapping = effectiveSubclassMapping(name, schema, openAPI)
+        // A discriminator base is a sealed superclass ONLY when it actually has
+        // subtypes. A discriminator base with no subtypes would otherwise become an
+        // empty, uninstantiable `sealed class`, so fall back to a normal (data/open)
+        // class — mirroring the Java class DTO styles — while keeping @JsonTypeInfo.
+        val isSealedBase = schema.discriminator != null && subclassMapping.isNotEmpty()
+        // The discriminator property is dropped from the constructor (managed by
+        // Jackson), so exclude it when deciding whether a `data class` is viable: a
+        // data class with zero components does not compile.
+        val ownDataPropertyCount = schema.properties?.keys
+            ?.count { it != schema.discriminator?.propertyName } ?: 0
+        val hasDataProperties = ownDataPropertyCount > 0
+            || inheritedProperties.isNotEmpty()
+            || schema.additionalProperties != null
+
         //This class is a superclass
         if (schema.discriminator != null) {
-            classBuilder.addModifiers(KModifier.SEALED)
+            if (isSealedBase) {
+                classBuilder.addModifiers(KModifier.SEALED)
+            }
             classBuilder.addAnnotation(
                 AnnotationSpec
                     .builder(JsonTypeInfo::class)
@@ -361,9 +378,8 @@ class KotlinTypeDefiner internal constructor(
                     .addMember("property = %S", schema.discriminator.propertyName)
                     .build()
             )
-        } else if (!(schema.properties.isNullOrEmpty() && schema.additionalProperties == null)
-            || inheritedProperties.isNotEmpty()
-        ) {
+        }
+        if (!isSealedBase && hasDataProperties) {
             classBuilder.addModifiers(KModifier.DATA)
         }
         //Intermediate class, can't be data, should be open
@@ -372,7 +388,6 @@ class KotlinTypeDefiner internal constructor(
             classBuilder.modifiers.remove(KModifier.DATA)
         }
 
-        val subclassMapping = effectiveSubclassMapping(name, schema, openAPI)
         if (subclassMapping.isNotEmpty()) {
             val mappings =
                 subclassMapping

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.childlessDiscriminatorRecordIsInstantiable.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.childlessDiscriminatorRecordIsInstantiable.approved.txt
@@ -1,0 +1,55 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Animal.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Cat.class, name = "Cat")})
+public sealed interface Animal permits Cat {
+  String name();
+}
+---
+/com/example/dto/Cat.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.Integer;
+import java.lang.String;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record Cat(String name, Integer clawLength) implements Animal {
+}
+---
+/com/example/dto/Thing.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "$type"
+)
+public record Thing(String id, String name) {
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -301,6 +301,20 @@ class CodegenTest {
         GeneratedCodeCompiler.assertJavaCompiles(result);
     }
 
+    @Test
+    void childlessDiscriminatorRecordIsInstantiable() throws IOException {
+        // In RECORDS style a discriminator base with no subtypes would become a
+        // bare, uninstantiable interface. It must fall back to a concrete record
+        // (keeping @JsonTypeInfo) so it can be created/deserialized, while a
+        // discriminator base WITH children (Animal) stays a sealed interface. The
+        // snapshot locks both shapes.
+        new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true)
+                .javaDtoStyle(JavaDtoStyle.RECORDS))
+                .generate(Path.of("src/test/resources/childlessDiscriminator.yaml"), result);
+        verify(result);
+    }
+
     @ParameterizedTest
     @EnumSource(JavaDtoStyle.class)
     void youtrackCompilesInAllStyles(JavaDtoStyle style) throws IOException {

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.childlessDiscriminatorFallsBackToInstantiable.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.childlessDiscriminatorFallsBackToInstantiable.approved.txt
@@ -1,0 +1,61 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Animal.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "kind",
+)
+@JsonSubTypes(JsonSubTypes.Type(value = Cat::class, name = "Cat"))
+public sealed class Animal(
+  public open val name: String? = null,
+)
+---
+/com/example/dto/Cat.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.Int
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Cat(
+  override val name: String? = null,
+  public val clawLength: Int? = null,
+) : Animal(name)
+---
+/com/example/dto/Thing.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "${'$'}type",
+)
+public data class Thing(
+  public val id: String? = null,
+  public val name: String? = null,
+)

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -197,6 +197,17 @@ class KCodegenTest {
         verify(result);
     }
 
+    @Test
+    void childlessDiscriminatorFallsBackToInstantiable() throws IOException {
+        // A discriminator base with no subtypes (no allOf children, no explicit
+        // mapping) would otherwise become an uninstantiable empty `sealed class`.
+        // It must fall back to a normal `data class` (keeping @JsonTypeInfo) so it
+        // can be created/deserialized, while a discriminator base WITH children
+        // (Animal) stays sealed. The snapshot locks both shapes.
+        codegen.generate(Path.of("src/test/resources/childlessDiscriminator.yaml"), result);
+        verify(result);
+    }
+
     @ParameterizedTest
     @EnumSource(Framework.class)
     void youtrackOpenapiCompiles(Framework framework) throws IOException {

--- a/src/test/resources/childlessDiscriminator.yaml
+++ b/src/test/resources/childlessDiscriminator.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info: {title: childlessDiscriminator, version: "1.0"}
+paths: {}
+components:
+  schemas:
+    # Discriminator base with NO subtypes (no allOf children, no explicit
+    # mapping). Must fall back to an instantiable type instead of an empty,
+    # uninstantiable sealed class / bare interface.
+    Thing:
+      type: object
+      discriminator:
+        propertyName: $type
+      properties:
+        id: {type: string}
+        name: {type: string}
+        $type: {type: string}
+    # Discriminator base WITH a child. Must stay polymorphic (sealed class /
+    # sealed interface) so selectivity of the fallback is proven.
+    Animal:
+      type: object
+      discriminator:
+        propertyName: kind
+      properties:
+        kind: {type: string}
+        name: {type: string}
+    Cat:
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+        - type: object
+          properties:
+            claw_length: {type: integer}

--- a/src/test/resources/roundtrip.yaml
+++ b/src/test/resources/roundtrip.yaml
@@ -59,6 +59,23 @@ components:
           items:
             $ref: '#/components/schemas/Inner'
 
+    # Discriminator base with NO subtypes (no allOf children, no explicit
+    # mapping). Falls back to an instantiable data class / record (keeping
+    # @JsonTypeInfo) instead of an uninstantiable empty sealed class / bare
+    # interface, so it must survive a full serialize -> deserialize round-trip.
+    Solo:
+      type: object
+      required: [solo_id]
+      discriminator:
+        propertyName: solo_kind
+      properties:
+        solo_id:
+          type: string
+        solo_count:
+          type: integer
+        solo_kind:
+          type: string
+
     # Discriminator base with two subtypes; the base carries a required
     # property (name) that every subtype inherits.
     Pet:


### PR DESCRIPTION
## Problem

A schema that declares a `discriminator` but has **no subtypes** (no `allOf` children and no explicit `mapping`) was generated as an **uninstantiable** type:

- Kotlin → empty `sealed class` (no subclasses ⇒ can't construct or deserialize)
- Java **RECORDS** → bare `interface` (same)

This shape is common in real specs — e.g. YouTrack's OpenAPI declares a `$type` discriminator on ~80 schemas that have no listed subtypes. Every such DTO was dead in Kotlin.

(Java `lombok`/`pojo` already emitted a concrete class, so those were fine.)

## Fix

Fall back to a concrete, instantiable type while keeping `@JsonTypeInfo` (matching the class styles):

- **Kotlin** — `data class` / `open class` instead of `sealed class` when the discriminator base has no derivable subtypes.
- **Java RECORDS** — a concrete `record` instead of a bare interface. The `@JsonTypeInfo` is attached inside `buildConcreteRecord` (an intermediate `toBuilder().addAnnotation()` approach silently dropped the record components, producing an empty `record X()` — avoided).

A discriminator base **with** children is unaffected (stays a sealed class / sealed interface).

Generated shape:

```
Thing   → data class / record Thing(...)  + @JsonTypeInfo        (childless: instantiable)
Animal  → sealed class / sealed interface + @JsonSubTypes(Cat)   (has child: stays polymorphic)
```

## Tests

- Approval snapshots for both fallbacks and the selectivity against a base with children (`childlessDiscriminator.yaml`).
- A subtype-less base (`Solo`) added to `roundtrip.yaml` so it is exercised by the full serialize → deserialize round-trip across **every** DTO style.

Full suite green (189 tests) + checkstyle.