### PR TITLE
Fix inline enums with non-identifier values (normalize like top-level enums)

### DIFF
--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -125,7 +125,7 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
                             enumBuilder.addModifiers(Modifier.STATIC);
                         }
                         for (Object e : schema.getEnum()) {
-                            enumBuilder.addEnumConstant(e.toString());
+                            addEnumValue(enumBuilder, e);
                         }
                         TypeSpec internalEnum = enumBuilder.build();
                         parent.addType(internalEnum);

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.generateSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.generateSample2.approved.txt
@@ -200,6 +200,7 @@ public class PlayerActivityDTO {
 /com/example/dto/PlayerDTO.java
 package com.example.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -243,11 +244,14 @@ public class PlayerDTO {
   private boolean duplicate;
 
   public enum Gender {
-    m,
+    @JsonProperty("m")
+    M,
 
-    f,
+    @JsonProperty("f")
+    F,
 
-    n
+    @JsonProperty("n")
+    N
   }
 }
 ---

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.inlineEnumNormalized.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.inlineEnumNormalized.approved.txt
@@ -1,0 +1,48 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Problem.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Problem {
+  private ErrorType errorType;
+
+  private Status status;
+
+  public enum ErrorType {
+    @JsonProperty("about:blank")
+    ABOUT_BLANK,
+
+    @JsonProperty("https://example.com/errors/validation")
+    HTTPS_EXAMPLE_COM_ERRORS_VALIDATION,
+
+    @JsonProperty("active")
+    ACTIVE
+  }
+}
+---
+/com/example/dto/Status.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum Status {
+  @JsonProperty("active")
+  ACTIVE,
+
+  @JsonProperty("archived")
+  ARCHIVED
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -119,6 +119,25 @@ class CodegenTest {
     }
 
     @Test
+    void inlineEnumWithNonIdentifierValuesCompiles() throws IOException {
+        // openapi-generator#24012: an inline (property-level) enum whose values
+        // are not legal Java identifiers ("about:blank", a URL) must be
+        // normalized like a top-level enum. Previously the inline path emitted
+        // the raw values verbatim, producing non-compiling Java.
+        codegen.generate(Path.of("src/test/resources/inlineenum.yaml"), result);
+        GeneratedCodeCompiler.assertJavaCompiles(result);
+    }
+
+    @Test
+    void inlineEnumNormalized() throws IOException {
+        // Locks the normalized shape: inline enum constants become
+        // SCREAMING_SNAKE_CASE with @JsonProperty preserving the wire value,
+        // matching the top-level enum path.
+        codegen.generate(Path.of("src/test/resources/inlineenum.yaml"), result);
+        verify(result);
+    }
+
+    @Test
     void dictionarySupport() throws IOException {
         codegen.generate(Path.of("src/test/resources/dictionary.yaml"), result);
         verify(result);

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.pojoSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.pojoSample2.approved.txt
@@ -514,6 +514,7 @@ public class PlayerActivityDTO {
 /com/example/dto/PlayerDTO.java
 package com.example.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -683,11 +684,14 @@ public class PlayerDTO {
   }
 
   public enum Gender {
-    m,
+    @JsonProperty("m")
+    M,
 
-    f,
+    @JsonProperty("f")
+    F,
 
-    n
+    @JsonProperty("n")
+    N
   }
 }
 ---

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusClientSample2.approved.txt
@@ -220,6 +220,7 @@ public class PlayerActivityDTO {
 /com/example/dto/PlayerDTO.java
 package com.example.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -263,11 +264,14 @@ public class PlayerDTO {
   private boolean duplicate;
 
   public enum Gender {
-    m,
+    @JsonProperty("m")
+    M,
 
-    f,
+    @JsonProperty("f")
+    F,
 
-    n
+    @JsonProperty("n")
+    N
   }
 }
 ---

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusGenerateSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusGenerateSample2.approved.txt
@@ -218,6 +218,7 @@ public class PlayerActivityDTO {
 /com/example/dto/PlayerDTO.java
 package com.example.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -261,11 +262,14 @@ public class PlayerDTO {
   private boolean duplicate;
 
   public enum Gender {
-    m,
+    @JsonProperty("m")
+    M,
 
-    f,
+    @JsonProperty("f")
+    F,
 
-    n
+    @JsonProperty("n")
+    N
   }
 }
 ---

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusServerAndClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.quarkusServerAndClientSample2.approved.txt
@@ -286,6 +286,7 @@ public class PlayerActivityDTO {
 /com/example/dto/PlayerDTO.java
 package com.example.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -329,11 +330,14 @@ public class PlayerDTO {
   private boolean duplicate;
 
   public enum Gender {
-    m,
+    @JsonProperty("m")
+    M,
 
-    f,
+    @JsonProperty("f")
+    F,
 
-    n
+    @JsonProperty("n")
+    N
   }
 }
 ---

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.recordsSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.recordsSample2.approved.txt
@@ -139,6 +139,7 @@ public record PlayerActivityDTO(String tag, String userId, String currency, Long
 /com/example/dto/PlayerDTO.java
 package com.example.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -154,11 +155,14 @@ public record PlayerDTO(String tag, String email, String userId, LocalDate dateO
     @JsonDeserialize(using = ZonedDateTimeDeserializer.class) @JsonSerialize(using = ZonedDateTimeSerializer.class) ZonedDateTime signUpAt,
     boolean duplicate) {
   public enum Gender {
-    m,
+    @JsonProperty("m")
+    M,
 
-    f,
+    @JsonProperty("f")
+    F,
 
-    n
+    @JsonProperty("n")
+    N
   }
 }
 ---

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.springAllRolesSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.springAllRolesSample2.approved.txt
@@ -294,6 +294,7 @@ public class PlayerActivityDTO {
 /com/example/dto/PlayerDTO.java
 package com.example.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -337,11 +338,14 @@ public class PlayerDTO {
   private boolean duplicate;
 
   public enum Gender {
-    m,
+    @JsonProperty("m")
+    M,
 
-    f,
+    @JsonProperty("f")
+    F,
 
-    n
+    @JsonProperty("n")
+    N
   }
 }
 ---

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.springClientSample2.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.springClientSample2.approved.txt
@@ -201,6 +201,7 @@ public class PlayerActivityDTO {
 /com/example/dto/PlayerDTO.java
 package com.example.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -244,11 +245,14 @@ public class PlayerDTO {
   private boolean duplicate;
 
   public enum Gender {
-    m,
+    @JsonProperty("m")
+    M,
 
-    f,
+    @JsonProperty("f")
+    F,
 
-    n
+    @JsonProperty("n")
+    N
   }
 }
 ---

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.inlineEnumNormalized.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.inlineEnumNormalized.approved.txt
@@ -1,0 +1,42 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Problem.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Problem(
+  public val errorType: ErrorType? = null,
+  public val status: Status? = null,
+) {
+  public enum class ErrorType {
+    @JsonProperty("about:blank")
+    ABOUT_BLANK,
+    @JsonProperty("https://example.com/errors/validation")
+    HTTPS_EXAMPLE_COM_ERRORS_VALIDATION,
+    @JsonProperty("active")
+    ACTIVE,
+  }
+}
+---
+/com/example/dto/Status.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+
+public enum class Status {
+  @JsonProperty("active")
+  ACTIVE,
+  @JsonProperty("archived")
+  ARCHIVED,
+}

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -77,6 +77,18 @@ class KCodegenTest {
     }
 
     @Test
+    void inlineEnumNormalized() throws IOException {
+        // Parity guard for OpenAPITools/openapi-generator#24012: unlike the Java
+        // generator (fixed separately), Kotlin already routes both inline and
+        // top-level enums through the same normalizing helper, so inline enum
+        // values that are not legal identifiers ("about:blank", a URL) become
+        // SCREAMING_SNAKE_CASE constants with @JsonProperty preserving the wire
+        // value. verify() snapshots the shape and confirms it compiles.
+        codegen.generate(Path.of("src/test/resources/inlineenum.yaml"), result);
+        verify(result);
+    }
+
+    @Test
     void generateCommonParameters() throws IOException {
         codegen.generate(Path.of("src/test/resources/commonparam.yaml"), result);
         verify(result);

--- a/src/test/resources/inlineenum.yaml
+++ b/src/test/resources/inlineenum.yaml
@@ -1,0 +1,32 @@
+# Reproducer for OpenAPITools/openapi-generator#24012 applied to hurdy-gurdy:
+# an inline (property-level) enum whose values are not legal Java identifiers
+# ("about:blank", a URL) must be normalized to SCREAMING_SNAKE_CASE constants
+# with @JsonProperty preserving the original wire value, exactly like a
+# top-level (named) enum. Previously the inline path emitted the raw values
+# verbatim, producing non-compiling Java.
+openapi: 3.0.1
+info:
+  title: Inline enum normalization
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Problem:
+      type: object
+      properties:
+        # inline enum with non-identifier values + a lowercase-but-legal value
+        error_type:
+          type: string
+          title: ErrorType
+          enum:
+            - about:blank
+            - https://example.com/errors/validation
+            - active
+        # a top-level enum for contrast (already normalized before the fix)
+        status:
+          $ref: '#/components/schemas/Status'
+    Status:
+      type: string
+      enum:
+        - active
+        - archived


### PR DESCRIPTION
## Summary

Fixes inline (property-level) enums whose values are not legal Java identifiers
producing **non-compiling Java**, and aligns their casing/JSON handling with
top-level enums. 

## The bug

A *top-level* enum (a named component schema) ran each value through
`addEnumValue`, which normalizes it to `SCREAMING_SNAKE_CASE` and attaches
`@JsonProperty(<original>)` so the JSON wire value is preserved. An *inline*
enum (declared directly on a property) instead emitted the raw value verbatim
(`enumBuilder.addEnumConstant(e.toString())`), skipping both steps.

For values that aren't legal Java identifiers this produced code that does not
compile. Given:

```yaml
error_type:
  type: string
  enum:
    - about:blank
    - https://example.com/errors/validation
```

the old output was:

```java
public enum ErrorType {
    about:blank,                              // <-- does not compile
    https://example.com/errors/validation
}
```

(`error: ',', '}', or ';' expected`). Even for legal-but-lowercase values the
constant kept an inconsistent case versus a top-level enum and carried no
`@JsonProperty`.

This affected **Java only** — the Kotlin generator already routes both its
inline and top-level enum paths through the same normalizing helper.

## The fix

Route the inline enum path through the same `addEnumValue` helper the top-level
path already uses (`JavaTypeDefiner`):

```diff
 for (Object e : schema.getEnum()) {
-    enumBuilder.addEnumConstant(e.toString());
+    addEnumValue(enumBuilder, e);
 }
```

Inline enums now render identically to top-level ones:

```java
public enum ErrorType {
    @JsonProperty("about:blank")
    ABOUT_BLANK,

    @JsonProperty("https://example.com/errors/validation")
    HTTPS_EXAMPLE_COM_ERRORS_VALIDATION
}
```

The `@JsonProperty` keeps the original wire value, so serialization is unchanged
for values that were already valid identifiers.

## Tests

- New fixture `src/test/resources/inlineenum.yaml` (the issue's construct:
  inline enum with `about:blank`, a URL, and a lowercase value).
- `CodegenTest.inlineEnumWithNonIdentifierValuesCompiles` — compile-only test
  that fails before the fix (non-compiling Java) and passes after.
- `CodegenTest.inlineEnumNormalized` — snapshot locking the normalized shape.
- Manually verified a Jackson round-trip: `{"error_type":"about:blank"}`
  deserializes to `ABOUT_BLANK` and re-serializes back to `"about:blank"`.

The 8 updated `*Sample2` snapshots reflect the same normalization applied to
`sample2.yaml`'s existing inline `Gender` enum (`m`/`f`/`n` →
`@JsonProperty("m") M`, etc.) — no other change.

## Not in scope

The issue's secondary ask — mapping `format: uri-reference` to `java.net.URI`
(as `format: uri` already does in openapi-generator) — is a separate feature and
is left as a follow-up. hurdy-gurdy currently maps both to `String`.
