### PR TITLE
Fix oneOf + discriminator emitting duplicate Jackson annotations (uncompilable)

### DIFF
--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -450,16 +450,18 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
     private record RecordComponent(String key, Schema<?> schema, boolean required) { }
 
     private TypeSpec buildRecordDto(String name, Schema<?> schema, OpenAPI openAPI) {
-        // 1) oneOf / top-level anyOf -> sealed interface (deduction-based Jackson polymorphism)
-        if (isPolymorphicInterface(schema)) {
-            return buildSealedInterface(name, schema, openAPI, false);
-        }
-        // 2) discriminator base WITH subtypes -> sealed interface (name-based
-        // polymorphism). A discriminator base with NO subtypes would become a bare,
-        // uninstantiable interface, so let it fall through to the concrete-record
-        // path below and re-attach @JsonTypeInfo — mirroring the class DTO styles.
-        if (schema.getDiscriminator() != null && !permittedSubtypes(name, schema, openAPI).isEmpty()) {
-            return buildSealedInterface(name, schema, openAPI, true);
+        // 1) oneOf / top-level anyOf, or a discriminator base WITH subtypes ->
+        // sealed interface. When a discriminator is present it wins: subtypes are
+        // selected by its property value (name-based) rather than DEDUCTION, so a
+        // schema declaring both oneOf and a discriminator yields a single set of
+        // Jackson annotations. Pure oneOf/anyOf (no discriminator) stays DEDUCTION.
+        // A discriminator base with NO subtypes would become a bare, uninstantiable
+        // interface, so let it fall through to the concrete-record path below and
+        // re-attach @JsonTypeInfo — mirroring the class DTO styles.
+        boolean hasDiscriminatorSubtypes = schema.getDiscriminator() != null
+                && !permittedSubtypes(name, schema, openAPI).isEmpty();
+        if (isPolymorphicInterface(schema) || hasDiscriminatorSubtypes) {
+            return buildSealedInterface(name, schema, openAPI, schema.getDiscriminator() != null);
         }
         // 3) concrete schema -> record (flatten allOf-inherited components). A
         // subtype-less discriminator base also lands here (buildConcreteRecord
@@ -1044,7 +1046,11 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
     }
 
     private void polymorphicToInterface(Schema<?> schema, OpenAPI openAPI, TypeSpec.Builder classBuilder) {
-        if (isPolymorphicInterface(schema)) {
+        // A discriminator, when present, selects subtypes by a property value
+        // (NAME-based, emitted by addDiscriminatorAnnotations) and takes precedence
+        // over oneOf/anyOf DEDUCTION. Emitting both would produce two @JsonTypeInfo
+        // and two @JsonSubTypes — neither is @Repeatable, so it would not compile.
+        if (isPolymorphicInterface(schema) && schema.getDiscriminator() == null) {
             var subtypesAnnotation = AnnotationSpec.builder(JsonSubTypes.class);
 
             final CodeBlock collect = polymorphicMembers(schema).stream()

--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -620,7 +620,11 @@ class KotlinTypeDefiner internal constructor(
 
 
     private fun polymorphicToInterface(schema: Schema<*>, openAPI: OpenAPI, classBuilder: TypeSpec.Builder) {
-        if (isPolymorphicInterface(schema)) {
+        // A discriminator, when present, selects subtypes by a property value
+        // (NAME-based, emitted in getDTOClass) and takes precedence over
+        // oneOf/anyOf DEDUCTION. Emitting both would produce two @JsonTypeInfo and
+        // two @JsonSubTypes — neither is repeatable, so it would not compile.
+        if (isPolymorphicInterface(schema) && schema.discriminator == null) {
             val builder = AnnotationSpec.builder(JsonSubTypes::class)
             polymorphicMembers(schema).asSequence()
                 .map { it.`$ref` }

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -138,6 +138,33 @@ class CodegenTest {
     }
 
     @Test
+    void oneOfWithDiscriminatorCompiles() throws IOException {
+        // openapi-generator#23997: a schema with BOTH oneOf and a discriminator
+        // previously emitted duplicate @JsonTypeInfo/@JsonSubTypes (a NAME-based
+        // pair and a DEDUCTION-based pair), which does not compile. The
+        // discriminator must win, leaving only the NAME-based annotations.
+        codegen.generate(Path.of("src/test/resources/oneofdiscriminator.yaml"), result);
+        GeneratedCodeCompiler.assertJavaCompiles(result);
+    }
+
+    @Test
+    void oneOfWithDiscriminator() throws IOException {
+        // Locks the shape: single NAME-based @JsonTypeInfo(property = "pet_type")
+        // + @JsonSubTypes from the discriminator mapping; no DEDUCTION pair.
+        codegen.generate(Path.of("src/test/resources/oneofdiscriminator.yaml"), result);
+        verify(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(JavaDtoStyle.class)
+    void allStylesCompileOneOfWithDiscriminator(JavaDtoStyle style) throws IOException {
+        new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .generateResponseParameter(true).javaDtoStyle(style))
+                .generate(Path.of("src/test/resources/oneofdiscriminator.yaml"), result);
+        GeneratedCodeCompiler.assertJavaCompiles(result);
+    }
+
+    @Test
     void dictionarySupport() throws IOException {
         codegen.generate(Path.of("src/test/resources/dictionary.yaml"), result);
         verify(result);

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.oneOfWithDiscriminator.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.oneOfWithDiscriminator.approved.txt
@@ -1,0 +1,56 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Cat.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Cat implements Pet {
+  private String meow;
+}
+---
+/com/example/dto/Dog.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Dog implements Pet {
+  private String bark;
+}
+---
+/com/example/dto/Pet.java
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "pet_type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Cat.class, name = "CAT"),
+    @JsonSubTypes.Type(value = Dog.class, name = "DOG")})
+public interface Pet {
+}

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -89,6 +89,17 @@ class KCodegenTest {
     }
 
     @Test
+    void oneOfWithDiscriminator() throws IOException {
+        // openapi-generator#23997: a schema with BOTH oneOf and a discriminator.
+        // Kotlin previously emitted duplicate @JsonTypeInfo/@JsonSubTypes (a
+        // DEDUCTION pair from oneOf plus a NAME-based pair from the discriminator),
+        // which does not compile. The discriminator wins; verify() snapshots the
+        // single NAME-based shape and confirms it compiles.
+        codegen.generate(Path.of("src/test/resources/oneofdiscriminator.yaml"), result);
+        verify(result);
+    }
+
+    @Test
     void generateCommonParameters() throws IOException {
         codegen.generate(Path.of("src/test/resources/commonparam.yaml"), result);
         verify(result);

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.oneOfWithDiscriminator.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.oneOfWithDiscriminator.approved.txt
@@ -1,0 +1,52 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Cat.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Cat(
+  public val meow: String? = null,
+) : Pet
+---
+/com/example/dto/Dog.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Dog(
+  public val bark: String? = null,
+) : Pet
+---
+/com/example/dto/Pet.kt
+package com.example.dto
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "pet_type",
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(value = Cat::class, name = "CAT"),
+  JsonSubTypes.Type(value = Dog::class, name = "DOG"),
+)
+public sealed interface Pet

--- a/src/test/resources/oneofdiscriminator.yaml
+++ b/src/test/resources/oneofdiscriminator.yaml
@@ -1,0 +1,41 @@
+# Reproducer for OpenAPITools/openapi-generator#23997 applied to hurdy-gurdy:
+# a schema that declares BOTH `oneOf` and a `discriminator`. This is a legal,
+# common OpenAPI shape (oneOf enumerates the subtypes; the discriminator names
+# the property that selects among them). hurdy-gurdy previously emitted two
+# @JsonTypeInfo and two @JsonSubTypes annotations (a NAME-based pair from the
+# discriminator plus a DEDUCTION-based pair from the oneOf), which does not
+# compile because those Jackson annotations are not @Repeatable. When a
+# discriminator is present it must win: only the NAME-based annotations are
+# emitted.
+openapi: 3.0.1
+info:
+  title: oneOf + discriminator
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - pet_type
+      properties:
+        pet_type:
+          type: string
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+      discriminator:
+        propertyName: pet_type
+        mapping:
+          CAT: '#/components/schemas/Cat'
+          DOG: '#/components/schemas/Dog'
+    Cat:
+      type: object
+      properties:
+        meow:
+          type: string
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: string


### PR DESCRIPTION
## Summary

Fixes a schema that declares **both** `oneOf` and a `discriminator` producing
uncompilable Java (and Kotlin), and — in records mode — silently dropping the
declared discriminator mapping. 

This is a legal, common OpenAPI shape: `oneOf` enumerates the permitted
subtypes, and the `discriminator` names the property that selects among them.

```yaml
Pet:
  type: object
  required: [pet_type]
  properties:
    pet_type: { type: string }
  oneOf:
    - $ref: '#/components/schemas/Cat'
    - $ref: '#/components/schemas/Dog'
  discriminator:
    propertyName: pet_type
    mapping:
      CAT: '#/components/schemas/Cat'
      DOG: '#/components/schemas/Dog'
```

## The bug

hurdy-gurdy has two independent polymorphism mechanisms, and this spec made
**both** fire on the same generated type:

- the **discriminator** path emitted name-based Jackson polymorphism —
  `@JsonTypeInfo(use = NAME, property = "pet_type")` + `@JsonSubTypes` from the
  mapping;
- the **oneOf** path emitted deduction-based polymorphism —
  `@JsonTypeInfo(use = DEDUCTION)` + a second `@JsonSubTypes`.

The result carried two `@JsonTypeInfo` and two `@JsonSubTypes` annotations.
Neither is `@Repeatable`, so the generated code does not compile:

```
Pet.java:20 com.fasterxml.jackson.annotation.JsonTypeInfo is not a repeatable annotation interface
Pet.java:17 com.fasterxml.jackson.annotation.JsonSubTypes is not a repeatable annotation interface
```

By style:

- **lombok / pojo** (Java) and **Kotlin data classes**: duplicate annotations →
  does not compile.
- **records** (Java): took the `oneOf` branch first and generated a valid but
  **DEDUCTION**-based sealed interface, silently ignoring the declared
  discriminator and its mapping.

## The fix

A discriminator, when present, selects subtypes by a property value and takes
precedence over `oneOf`/`anyOf` DEDUCTION. The two schemes are now mutually
exclusive:

- `JavaTypeDefiner.polymorphicToInterface` and `KotlinTypeDefiner.polymorphicToInterface`
  emit the DEDUCTION annotations only when the schema has **no** discriminator
  (the discriminator path already emits the name-based pair).
- `JavaTypeDefiner.buildRecordDto` (records) now routes a schema with a
  discriminator to a **name-based** sealed interface, so the mapping is honored
  instead of dropped.

Pure `oneOf`/`anyOf` (no discriminator) and discriminator-only schemas are
unchanged.

Generated `Pet` now carries a single name-based pair, and `Cat`/`Dog` implement
it:

```java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "pet_type")
@JsonSubTypes({
    @JsonSubTypes.Type(value = Cat.class, name = "CAT"),
    @JsonSubTypes.Type(value = Dog.class, name = "DOG")})
public interface Pet {}
```

## Tests

- New fixture `src/test/resources/oneofdiscriminator.yaml` (the `oneOf` +
  `discriminator` shape).
- `CodegenTest.oneOfWithDiscriminatorCompiles` — compile-only, fails before the
  fix; `allStylesCompileOneOfWithDiscriminator` covers lombok/pojo/records.
- `CodegenTest.oneOfWithDiscriminator` / `KCodegenTest.oneOfWithDiscriminator` —
  snapshots locking the single name-based shape.
- Manually verified a Jackson round-trip: a `Cat` serializes through `Pet` to
  `{"pet_type":"CAT",...}` and deserializes back to `Cat`; `{"pet_type":"DOG"}`
  deserializes to `Dog`.
