### PR TITLE
Fix non-compiling Kotlin for object-level defaults on $ref properties

### DIFF
--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -592,6 +592,18 @@ class KotlinTypeDefiner internal constructor(
                     paramSpec.defaultValue("%T()", typeName.copy(nullable = false))
                 }
 
+                value.`$ref` != null -> {
+                    // A $ref default that is neither an enum constant nor an empty
+                    // object (handled above) is a structured object default, e.g.
+                    // {order: SIMILARITY, limit: 10}. It cannot be rendered as a
+                    // Kotlin initializer expression, so drop it — matching the Java
+                    // generator, which emits no initializer for object defaults —
+                    // and fall back to null for an optional property.
+                    if (!required) {
+                        paramSpec.defaultValue("null")
+                    }
+                }
+
                 else -> {
                     //Everything else (e.g., numbers)
                     paramSpec.defaultValue("%L", default.toString())

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -138,6 +138,16 @@ class CodegenTest {
     }
 
     @Test
+    void objectDefaultOnRefProperty() throws IOException {
+        // openapi-generator#24298: the Java generator already drops an object-level
+        // default on a $ref property (Lombok fields carry no initializer), so the
+        // output compiles. This locks that behavior as the parity baseline for the
+        // Kotlin fix.
+        codegen.generate(Path.of("src/test/resources/objectdefault.yaml"), result);
+        verify(result);
+    }
+
+    @Test
     void oneOfWithDiscriminatorCompiles() throws IOException {
         // openapi-generator#23997: a schema with BOTH oneOf and a discriminator
         // previously emitted duplicate @JsonTypeInfo/@JsonSubTypes (a NAME-based

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.objectDefaultOnRefProperty.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.objectDefaultOnRefProperty.approved.txt
@@ -1,0 +1,43 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Formatter.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Formatter {
+  private OutputFormat format;
+}
+---
+/com/example/dto/OutputFormat.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.Integer;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OutputFormat {
+  private Order order;
+
+  private Integer limit;
+
+  public enum Order {
+    IMPORTANCE,
+
+    SIMILARITY
+  }
+}

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -89,6 +89,23 @@ class KCodegenTest {
     }
 
     @Test
+    void objectDefaultOnRefPropertyCompiles() throws IOException {
+        // openapi-generator#24298: a $ref property whose referenced object has an
+        // object-level default previously pasted that default's JSON verbatim as
+        // the Kotlin initializer, which does not compile. The structured default
+        // must be dropped, leaving the optional property's null default.
+        codegen.generate(Path.of("src/test/resources/objectdefault.yaml"), result);
+        GeneratedCodeCompiler.assertKotlinCompiles(result);
+    }
+
+    @Test
+    void objectDefaultOnRefProperty() throws IOException {
+        // Locks the shape: format falls back to `= null`, not the raw JSON default.
+        codegen.generate(Path.of("src/test/resources/objectdefault.yaml"), result);
+        verify(result);
+    }
+
+    @Test
     void oneOfWithDiscriminator() throws IOException {
         // openapi-generator#23997: a schema with BOTH oneOf and a discriminator.
         // Kotlin previously emitted duplicate @JsonTypeInfo/@JsonSubTypes (a

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.objectDefaultOnRefProperty.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.objectDefaultOnRefProperty.approved.txt
@@ -1,0 +1,37 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Formatter.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Formatter(
+  public val format: OutputFormat? = null,
+)
+---
+/com/example/dto/OutputFormat.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.Int
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class OutputFormat(
+  public val order: Order? = null,
+  public val limit: Int? = null,
+) {
+  public enum class Order {
+    IMPORTANCE,
+    SIMILARITY,
+  }
+}

--- a/src/test/resources/objectdefault.yaml
+++ b/src/test/resources/objectdefault.yaml
@@ -1,0 +1,33 @@
+# Reproducer for OpenAPITools/openapi-generator#23997's sibling #24298 applied to
+# hurdy-gurdy: a $ref property whose referenced object schema carries an
+# object-level `default`. hurdy-gurdy's Kotlin generator pasted that default's
+# JSON toString straight into the initializer
+# (`val format: OutputFormat? = {"order":"SIMILARITY","limit":10}`), which does
+# not compile. A structured object default cannot be rendered as an initializer
+# expression, so it is dropped (as the Java generator already does) and the
+# optional property falls back to null.
+openapi: "3.1.0"
+info:
+  title: Object default on $ref property
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    OutputFormat:
+      type: object
+      properties:
+        order:
+          type: string
+          enum:
+            - IMPORTANCE
+            - SIMILARITY
+        limit:
+          type: integer
+      default:
+        order: SIMILARITY
+        limit: 10
+    Formatter:
+      type: object
+      properties:
+        format:
+          $ref: '#/components/schemas/OutputFormat'


### PR DESCRIPTION
## Summary

Fixes non-compiling Kotlin output when a `$ref` property points to an object
schema that declares an object-level `default`.

## The bug

Given a property that references an object schema carrying a default:

```yaml
OutputFormat:
  type: object
  properties:
    order: { type: string, enum: [IMPORTANCE, SIMILARITY] }
    limit: { type: integer }
  default:
    order: SIMILARITY
    limit: 10
Formatter:
  type: object
  properties:
    format:
      $ref: '#/components/schemas/OutputFormat'
```

the Kotlin generator pasted the default's JSON `toString()` straight into the
constructor initializer:

```kotlin
public data class Formatter(
  public val format: OutputFormat? = {"order":"SIMILARITY","limit":10},   // does not compile
)
```

The property-default handling has dedicated branches for the cases it can render
(scalars, strings, enum constants, an empty object `{}`), but a **non-empty
structured object** default fell through to the catch-all branch, which pastes
`default.toString()` verbatim — valid only for scalars.

The Java generator was unaffected: its Lombok/POJO fields never carry
initializers, so it already compiled and simply ignored the object default.

## The fix

A structured object default cannot be expressed as a Kotlin initializer, so it
is dropped and the optional property falls back to `null` — matching the Java
generator's behavior. Concretely, `KotlinTypeDefiner` gains one branch, after
the enum and empty-object cases, that catches any remaining `$ref` default and
emits `= null` for an optional property instead of the raw value.

```kotlin
public data class Formatter(
  public val format: OutputFormat? = null,   // compiles
)
```

Scalar, string, enum and empty-object defaults are unchanged.

## Tests

- New fixture `src/test/resources/objectdefault.yaml`.
- `KCodegenTest.objectDefaultOnRefPropertyCompiles` — compile-only, fails before
  the fix (`Syntax error: Unexpected tokens`), passes after.
- `KCodegenTest.objectDefaultOnRefProperty` — snapshot locking `= null`.
- `CodegenTest.objectDefaultOnRefProperty` — snapshot locking the Java parity
  baseline (`private OutputFormat format;`, no initializer).

Full test suite passes (218 tests) with no changes to any existing snapshot.

## Note

This drops the object default rather than constructing it
(`OutputFormat(order = Order.SIMILARITY, limit = 10)`). Constructing it would
honor the default but is materially more complex (mapping each key to a
constructor argument, converting enum strings to nested enum constants) and
would diverge from the Java generator, which drops object defaults. Honoring
object defaults across both languages would be a separate enhancement.
