### PR TITLE
Fix records rejecting explicit null for required + nullable properties

### DIFF
--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -647,7 +647,11 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
                 ensureJsonZonedDateTimeDeserializer();
             }
             canonical.addParameter(param.build());
-            if (c.required()) {
+            // A property that is `required` AND `nullable` must be present but may
+            // hold an explicit null (OpenAPI 3.0 semantics), so it must NOT be
+            // null-checked — otherwise a valid {"x":null} payload fails to
+            // deserialize. Only non-nullable required components are enforced.
+            if (c.required() && !isNullable(c.schema(), openAPI)) {
                 requiredNames.add(propertyName);
             }
         }
@@ -661,6 +665,23 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
             recordBuilder.addMethod(compact.build());
         }
         return recordBuilder.build();
+    }
+
+    /**
+     * Whether a schema permits an explicit {@code null} value: an OpenAPI 3.0
+     * {@code nullable: true}, a same-file {@code $ref} to a nullable schema, or a
+     * 3.1 {@code anyOf:[X, null]} nullable wrapper.
+     */
+    private boolean isNullable(Schema<?> schema, OpenAPI openAPI) {
+        if (Boolean.TRUE.equals(schema.getNullable())) {
+            return true;
+        }
+        if (schema.get$ref() != null) {
+            return getNullable(openAPI, extractGroup(schema.get$ref(), CLASS_NAME_PATTERN), false);
+        }
+        List<Schema> anyOf = schema.getAnyOf();
+        return anyOf != null && anyOf.size() == 2
+                && anyOf.stream().anyMatch(s -> "null".equals(getInternalType(s)));
     }
 
     private void addAdditionalPropertiesComponent(Schema<?> schema, OpenAPI openAPI,

--- a/src/test/java/ru/curs/hurdygurdy/RecordRequiredNullableTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/RecordRequiredNullableTest.java
@@ -1,0 +1,54 @@
+package ru.curs.hurdygurdy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Functional test for a property that is both {@code required} and
+ * {@code nullable: true} in {@code records} DTO style.
+ *
+ * <p>Per OpenAPI 3.0 such a property must be present but its value may be
+ * {@code null}, so {@code {"foo":"x","baz":null}} is a valid payload. The
+ * snapshot only checks the <em>text</em> of the compact constructor; here we
+ * generate the record, compile it, load it and run it through a Jackson
+ * {@link ObjectMapper} to prove the valid explicit {@code null} deserializes —
+ * while a required, non-nullable property still rejects a missing value.
+ */
+class RecordRequiredNullableTest {
+
+    private static final String SPEC = "src/test/resources/recordsnullable.yaml";
+
+    @TempDir
+    private Path generated;
+
+    @Test
+    void requiredNullablePropertyAcceptsExplicitNull() throws Exception {
+        new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .javaDtoStyle(JavaDtoStyle.RECORDS))
+                .generate(Path.of(SPEC), generated);
+        Path classes = GeneratedCodeCompiler.compileJava(generated);
+        try (URLClassLoader loader = GeneratedCodeCompiler.classLoaderFor(classes)) {
+            Class<?> foo = loader.loadClass("com.example.dto.Foo");
+            ObjectMapper mapper = new ObjectMapper();
+
+            // required + nullable `baz` present with an explicit null: valid.
+            Object value = mapper.readValue("{\"foo\":\"x\",\"baz\":null}", foo);
+            assertThat(value).isNotNull();
+            assertThat(foo.getMethod("baz").invoke(value)).isNull();
+            assertThat(foo.getMethod("foo").invoke(value)).isEqualTo("x");
+
+            // required + NOT nullable `foo` missing: still rejected.
+            assertThatThrownBy(() -> mapper.readValue("{\"baz\":\"y\"}", foo))
+                    .hasMessageContaining("foo");
+        } finally {
+            TestFiles.deleteRecursively(classes);
+        }
+    }
+}

--- a/src/test/resources/recordsnullable.yaml
+++ b/src/test/resources/recordsnullable.yaml
@@ -1,0 +1,27 @@
+# A DTO with properties that are BOTH `required` and `nullable: true`. Per
+# OpenAPI 3.0, such a property must be PRESENT but its value MAY be null, so
+# {"foo":"x","baz":null} is a valid payload. In records mode hurdy-gurdy emitted
+# Objects.requireNonNull for every required component, ignoring nullable, so the
+# compact constructor rejected the (valid) explicit null. `foo` is required and
+# NOT nullable, so its non-null enforcement must be kept.
+openapi: "3.0.2"
+info:
+  title: Records required + nullable
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        foo:
+          type: string
+        bar:
+          type: string
+          nullable: true
+        baz:
+          type: string
+          nullable: true
+      required:
+        - foo
+        - baz


### PR DESCRIPTION
## Summary

Fixes `records` DTO style rejecting valid payloads for a property that is both
`required` and `nullable`.

## The bug

In records style, the generated compact constructor added an
`Objects.requireNonNull(...)` check for **every** `required` component. But per
OpenAPI 3.0, a property that is `required` **and** `nullable: true` must be
*present* while its value may be an explicit `null` — so `{"foo":"x","baz":null}`
is a valid payload. The null check rejected it: Jackson deserialization failed
with

```
ValueInstantiationException: Cannot construct instance of `Foo`, problem: baz
Caused by: java.lang.NullPointerException: baz
```

for a schema like:

```yaml
Foo:
  type: object
  properties:
    foo: { type: string }
    baz: { type: string, nullable: true }
  required: [foo, baz]
```

(The Kotlin generator was unaffected — it already emits a nullable component.)

## The fix

A required component is null-checked only when it is **not** nullable. The
compact constructor now enforces non-null for required, non-nullable components
and leaves required-nullable ones free to hold an explicit `null`:

```java
public record Foo(String foo, String bar, String baz) {
  public Foo {
    Objects.requireNonNull(foo, "foo");   // required + non-nullable: enforced
  }                                        // baz (required + nullable): not checked
}
```

A new `isNullable` helper recognizes the three ways a schema admits `null`:
`nullable: true`, a same-file `$ref` to a nullable schema, and a `anyOf:[X, null]`
wrapper.

## Tests

- New fixture `src/test/resources/recordsnullable.yaml`.
- `RecordRequiredNullableTest` — a runtime test (not just a snapshot): it
  generates the record, compiles it, loads it and drives it through a Jackson
  `ObjectMapper`, asserting that
  - `{"foo":"x","baz":null}` deserializes with `baz() == null`, and
  - `{"baz":"y"}` (missing the required, non-nullable `foo`) still throws, so
    non-null enforcement is preserved where it belongs.

Full test suite passes (219 tests) with no changes to any existing snapshot.
