### PR TITLE
Generate position-correct types for format: binary (bodies/responses/properties, not just multipart)

### DIFF
--- a/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaAPIExtractor.java
@@ -71,6 +71,17 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
             ClassName.get("org.springframework.web.service.annotation", "DeleteExchange");
     private static final ClassName SPRING_RESPONSE_ENTITY =
             ClassName.get("org.springframework.http", "ResponseEntity");
+    // Position-dependent target types for `format: binary`. A multipart part is a
+    // MultipartFile/FileUpload; a raw body or a response is a converter-backed
+    // body type (Spring Resource / JAX-RS InputStream). A bare binary DTO property
+    // is byte[] and handled by the type definer, not here.
+    private static final ClassName MULTIPART_FILE =
+            ClassName.get("org.springframework.web.multipart", "MultipartFile");
+    private static final ClassName QUARKUS_FILE_UPLOAD =
+            ClassName.get("org.jboss.resteasy.reactive.multipart", "FileUpload");
+    private static final ClassName SPRING_RESOURCE =
+            ClassName.get("org.springframework.core.io", "Resource");
+    private static final ClassName INPUT_STREAM = ClassName.get(java.io.InputStream.class);
 
     public JavaAPIExtractor(TypeDefiner<TypeSpec> typeDefiner,
                             GeneratorParams params) {
@@ -413,8 +424,12 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                         .entrySet()
                         .stream()
                         .map(e -> new RequestPartParams(
-                                JavaAPIExtractor.safeUnbox(typeDefiner.defineJavaType(e.getValue(), openAPI,
-                                        parent, null)),
+                                // A binary part is an uploaded file (MultipartFile /
+                                // FileUpload); other parts resolve normally.
+                                isBinary(e.getValue())
+                                        ? multipartPartType()
+                                        : JavaAPIExtractor.safeUnbox(typeDefiner.defineJavaType(e.getValue(),
+                                                openAPI, parent, null)),
                                 e.getKey(),
                                 quarkus
                                         ? AnnotationSpec.builder(QUARKUS_REST_FORM)
@@ -424,8 +439,12 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
             } else {
                 //Single-part
                 return Optional.ofNullable(entry.getValue().getSchema()).stream()
-                        .map(s -> typeDefiner.defineJavaType(s, openAPI, parent, null))
-                        .map(JavaAPIExtractor::safeUnbox).map(t ->
+                        // A binary single-part body/response is a converter-backed
+                        // body type (Resource / InputStream), not a multipart part.
+                        .map(s -> isBinary(s)
+                                ? binaryBodyType()
+                                : JavaAPIExtractor.safeUnbox(typeDefiner.defineJavaType(s, openAPI, parent, null)))
+                        .map(t ->
                                 new RequestPartParams(t,
                                         "request",
                                         quarkus
@@ -435,6 +454,32 @@ public class JavaAPIExtractor extends APIExtractor<TypeSpec, TypeSpec.Builder> {
                                                         .build()));
             }
         }
+    }
+
+    /** Whether a schema is {@code type: string, format: binary} (OpenAPI 3.0 or 3.1). */
+    private static boolean isBinary(Schema<?> schema) {
+        if (schema == null) {
+            return false;
+        }
+        String type = schema.getType();
+        if (type == null && schema.getTypes() != null && schema.getTypes().size() == 1) {
+            type = schema.getTypes().iterator().next();
+        }
+        return "string".equals(type) && "binary".equals(schema.getFormat());
+    }
+
+    /**
+     * Type of a binary multipart part: an uploaded file. Keyed on the actual
+     * framework rather than the annotation-context flag, since a return type
+     * derives its content with that flag hardcoded to {@code false}.
+     */
+    private ClassName multipartPartType() {
+        return getFramework() == Framework.QUARKUS ? QUARKUS_FILE_UPLOAD : MULTIPART_FILE;
+    }
+
+    /** Type of a binary single-part request/response body: a converter-backed stream. */
+    private ClassName binaryBodyType() {
+        return getFramework() == Framework.QUARKUS ? INPUT_STREAM : SPRING_RESOURCE;
     }
 
     private List<AnnotationSpec> getQuarkusMethodAnnotations(

--- a/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
+++ b/src/main/java/ru/curs/hurdygurdy/JavaTypeDefiner.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.javapoet.AnnotationSpec;
+import com.palantir.javapoet.ArrayTypeName;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
 import com.palantir.javapoet.FieldSpec;
@@ -32,8 +33,6 @@ import io.swagger.v3.oas.models.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
-
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.time.DateTimeException;
@@ -114,9 +113,12 @@ public final class JavaTypeDefiner extends TypeDefiner<TypeSpec> {
                     } else if ("uuid".equals(schema.getFormat())) {
                         return ClassName.get(UUID.class);
                     } else if ("binary".equals(schema.getFormat())) {
-                        return params.getFramework() == Framework.QUARKUS
-                                ? ClassName.get("org.jboss.resteasy.reactive.multipart", "FileUpload")
-                                : ClassName.get(MultipartFile.class);
+                        // A bare binary schema — a DTO property / JSON value — is
+                        // base64-encoded in JSON, so it maps to byte[]. Binary
+                        // request/response BODIES and multipart parts are position-
+                        // dependent and handled by the API extractor (which maps
+                        // them to Resource/InputStream/MultipartFile/FileUpload).
+                        return ArrayTypeName.of(TypeName.BYTE);
                     } else if (schema.getEnum() != null) {
                         //internal enum
                         String simpleName = getEnumName(schema, typeNameFallback);

--- a/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinAPIExtractor.kt
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.parameters.RequestBody
 import org.springframework.web.bind.annotation.*
@@ -71,6 +72,15 @@ class KotlinAPIExtractor(
         val SPRING_PATCH_EXCHANGE = ClassName("org.springframework.web.service.annotation", "PatchExchange")
         val SPRING_DELETE_EXCHANGE = ClassName("org.springframework.web.service.annotation", "DeleteExchange")
         val SPRING_RESPONSE_ENTITY = ClassName("org.springframework.http", "ResponseEntity")
+
+        // Position-dependent target types for `format: binary`: a multipart part is
+        // a MultipartFile/FileUpload, a raw body or response is a converter-backed
+        // body type (Spring Resource / JAX-RS InputStream). A bare binary DTO
+        // property is ByteArray and handled by the type definer.
+        val MULTIPART_FILE = ClassName("org.springframework.web.multipart", "MultipartFile")
+        val QUARKUS_FILE_UPLOAD = ClassName("org.jboss.resteasy.reactive.multipart", "FileUpload")
+        val SPRING_RESOURCE = ClassName("org.springframework.core.io", "Resource")
+        val INPUT_STREAM = ClassName("java.io", "InputStream")
     }
 
     public override fun buildMethod(
@@ -509,7 +519,10 @@ class KotlinAPIExtractor(
                     .map { (name, schema) ->
                         RequestPartParams(
                             name = name,
-                            typeName = typeDefiner.defineKotlinType(schema, openAPI, parent, null, null),
+                            // A binary part is an uploaded file (MultipartFile /
+                            // FileUpload); other parts resolve normally.
+                            typeName = if (isBinary(schema)) multipartPartType()
+                            else typeDefiner.defineKotlinType(schema, openAPI, parent, null, null),
                             annotation = if (quarkus)
                                 AnnotationSpec.builder(QUARKUS_REST_FORM)
                                     .addMember("%S", name).build()
@@ -522,7 +535,12 @@ class KotlinAPIExtractor(
             } else {
                 //Single-part
                 Optional.ofNullable(entry.value.schema).stream().asSequence()
-                    .map { typeDefiner.defineKotlinType(it, openAPI, parent, null, null) }
+                    // A binary single-part body/response is a converter-backed body
+                    // type (Resource / InputStream), not a multipart part.
+                    .map {
+                        if (isBinary(it)) binaryBodyType()
+                        else typeDefiner.defineKotlinType(it, openAPI, parent, null, null)
+                    }
                     .map {
                         RequestPartParams(
                             name = "request",
@@ -538,4 +556,22 @@ class KotlinAPIExtractor(
             }
         }
     }
+
+    /** Whether a schema is `type: string, format: binary` (OpenAPI 3.0 or 3.1). */
+    private fun isBinary(schema: Schema<*>?): Boolean {
+        if (schema == null) {
+            return false
+        }
+        val type = schema.type ?: schema.types?.singleOrNull()
+        return "string" == type && "binary" == schema.format
+    }
+
+    // Keyed on the actual framework (not the annotation-context flag, which a
+    // return type derives with `quarkus = false`). Nullable to match the
+    // surrounding generated body/part types.
+    private fun multipartPartType(): TypeName =
+        (if (framework == Framework.QUARKUS) QUARKUS_FILE_UPLOAD else MULTIPART_FILE).copy(nullable = true)
+
+    private fun binaryBodyType(): TypeName =
+        (if (framework == Framework.QUARKUS) INPUT_STREAM else SPRING_RESOURCE).copy(nullable = true)
 }

--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -38,7 +38,6 @@ import com.squareup.kotlinpoet.asTypeName
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.media.Schema
-import org.springframework.web.multipart.MultipartFile
 import ru.curs.hurdygurdy.CaseUtils.normalizeToScreamingSnake
 import java.time.DateTimeException
 import java.time.LocalDate
@@ -96,9 +95,11 @@ class KotlinTypeDefiner internal constructor(
                     "date" == schema.format -> LocalDate::class.asTypeName()
                     "date-time" == schema.format -> ZonedDateTime::class.asTypeName()
                     "uuid" == schema.format -> UUID::class.asTypeName()
-                    "binary" == schema.format -> if (params.framework == Framework.QUARKUS)
-                        ClassName("org.jboss.resteasy.reactive.multipart", "FileUpload")
-                    else MultipartFile::class.asTypeName()
+                    // A bare binary schema (a DTO property / JSON value) is base64
+                    // in JSON, so it maps to ByteArray. Binary request/response
+                    // BODIES and multipart parts are position-dependent and handled
+                    // by the API extractor.
+                    "binary" == schema.format -> ByteArray::class.asTypeName()
                     schema.enum != null -> {
                         //internal enum
                         val simpleName = getEnumName(schema, typeNameFallback)

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryDtoPropertyJava.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryDtoPropertyJava.approved.txt
@@ -1,0 +1,24 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Document.java
+package com.example.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.String;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Document {
+  private String name;
+
+  private byte[] content;
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryRequestBodyTypeQuarkus.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryRequestBodyTypeQuarkus.approved.txt
@@ -1,0 +1,24 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import java.io.InputStream;
+
+@Path("")
+public interface Controller {
+  @POST
+  @Path("/upload")
+  @Consumes("application/octet-stream")
+  void upload(InputStream request);
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryRequestBodyTypeSpring.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryRequestBodyTypeSpring.approved.txt
@@ -1,0 +1,24 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.io.Resource;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface Controller {
+  @PostMapping(
+      value = "/upload",
+      consumes = "application/octet-stream"
+  )
+  void upload(@RequestBody Resource request, HttpServletResponse response);
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryResponseTypeQuarkus.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryResponseTypeQuarkus.approved.txt
@@ -1,0 +1,24 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import java.io.InputStream;
+
+@Path("")
+public interface Controller {
+  @GET
+  @Path("/download")
+  @Produces("application/octet-stream")
+  InputStream download();
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryResponseTypeSpring.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.binaryResponseTypeSpring.approved.txt
@@ -1,0 +1,23 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.java
+package com.example.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.io.Resource;
+import org.springframework.web.bind.annotation.GetMapping;
+
+public interface Controller {
+  @GetMapping(
+      value = "/download",
+      produces = "application/octet-stream"
+  )
+  Resource download(HttpServletResponse response);
+}

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.java
@@ -175,6 +175,48 @@ class CodegenTest {
     }
 
     @Test
+    void binaryResponseTypeSpring() throws IOException {
+        // A binary (format: binary) download response must return a body type a
+        // Spring message converter can write (Resource), never MultipartFile.
+        codegen.generate(Path.of("src/test/resources/binarydownload.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void binaryResponseTypeQuarkus() throws IOException {
+        // Quarkus controller (no response envelope) returns the body type; a binary
+        // response must be InputStream, never FileUpload.
+        new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .framework(Framework.QUARKUS).generateResponseParameter(false))
+                .generate(Path.of("src/test/resources/binarydownload.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void binaryRequestBodyTypeSpring() throws IOException {
+        // A raw (non-multipart) octet-stream request body must be a readable body
+        // type (Resource), never MultipartFile.
+        codegen.generate(Path.of("src/test/resources/binaryrawbody.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void binaryRequestBodyTypeQuarkus() throws IOException {
+        new JavaCodegen(GeneratorParams.rootPackage("com.example")
+                .framework(Framework.QUARKUS).generateResponseParameter(false))
+                .generate(Path.of("src/test/resources/binaryrawbody.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void binaryDtoPropertyJava() throws IOException {
+        // A binary property inside a JSON DTO must be byte[] (base64), never
+        // MultipartFile.
+        codegen.generate(Path.of("src/test/resources/binaryproperty.yaml"), result);
+        verify(result);
+    }
+
+    @Test
     void dictionarySupport() throws IOException {
         codegen.generate(Path.of("src/test/resources/dictionary.yaml"), result);
         verify(result);

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.binaryDtoPropertyKotlin.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.binaryDtoPropertyKotlin.approved.txt
@@ -1,0 +1,22 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/dto
+---
+/com/example/dto/Document.kt
+package com.example.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.`annotation`.JsonNaming
+import kotlin.ByteArray
+import kotlin.String
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy::class)
+public data class Document(
+  public val name: String? = null,
+  public val content: ByteArray? = null,
+)

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.binaryRequestBodyTypeSpring.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.binaryRequestBodyTypeSpring.approved.txt
@@ -1,0 +1,24 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.io.Resource
+import org.springframework.web.bind.`annotation`.PostMapping
+import org.springframework.web.bind.`annotation`.RequestBody
+
+public interface Controller {
+  @PostMapping(
+    value = ["/upload"],
+    consumes = ["application/octet-stream"],
+  )
+  public fun upload(@RequestBody request: Resource?, response: HttpServletResponse)
+}

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.binaryResponseTypeSpring.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.binaryResponseTypeSpring.approved.txt
@@ -1,0 +1,23 @@
+---
+
+---
+/com
+---
+/com/example
+---
+/com/example/controller
+---
+/com/example/controller/Controller.kt
+package com.example.controller
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.io.Resource
+import org.springframework.web.bind.`annotation`.GetMapping
+
+public interface Controller {
+  @GetMapping(
+    value = ["/download"],
+    produces = ["application/octet-stream"],
+  )
+  public fun download(response: HttpServletResponse): Resource?
+}

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.java
@@ -117,6 +117,30 @@ class KCodegenTest {
     }
 
     @Test
+    void binaryResponseTypeSpring() throws IOException {
+        // A binary download response must return a body type a Spring message
+        // converter can write (Resource), never MultipartFile.
+        codegen.generate(Path.of("src/test/resources/binarydownload.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void binaryRequestBodyTypeSpring() throws IOException {
+        // A raw octet-stream request body must be a readable body type (Resource),
+        // never MultipartFile.
+        codegen.generate(Path.of("src/test/resources/binaryrawbody.yaml"), result);
+        verify(result);
+    }
+
+    @Test
+    void binaryDtoPropertyKotlin() throws IOException {
+        // A binary property inside a JSON DTO must be ByteArray (base64), never
+        // MultipartFile.
+        codegen.generate(Path.of("src/test/resources/binaryproperty.yaml"), result);
+        verify(result);
+    }
+
+    @Test
     void generateCommonParameters() throws IOException {
         codegen.generate(Path.of("src/test/resources/commonparam.yaml"), result);
         verify(result);

--- a/src/test/resources/binarydownload.yaml
+++ b/src/test/resources/binarydownload.yaml
@@ -1,0 +1,21 @@
+# Binary file-download response: the 2xx body is `type: string, format: binary`.
+# The generated method must return a body type a message converter can write
+# (Spring Resource / Quarkus InputStream), never MultipartFile/FileUpload (those
+# are inbound multipart upload parts only).
+openapi: 3.0.1
+info:
+  title: Binary download
+  version: 1.0.0
+paths:
+  /download:
+    get:
+      operationId: download
+      responses:
+        '200':
+          description: the file
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+components: {}

--- a/src/test/resources/binaryproperty.yaml
+++ b/src/test/resources/binaryproperty.yaml
@@ -1,0 +1,18 @@
+# A binary property inside a JSON DTO. In JSON such a value is base64-encoded, so
+# the field must be byte[] (Java) / ByteArray (Kotlin) — Jackson base64s it — not
+# MultipartFile.
+openapi: 3.0.1
+info:
+  title: Binary property
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Document:
+      type: object
+      properties:
+        name:
+          type: string
+        content:
+          type: string
+          format: binary

--- a/src/test/resources/binaryrawbody.yaml
+++ b/src/test/resources/binaryrawbody.yaml
@@ -1,0 +1,21 @@
+# Raw (non-multipart) binary request body: application/octet-stream with
+# `type: string, format: binary`. The body parameter must be a readable body
+# type (Spring Resource / Quarkus InputStream), never MultipartFile/FileUpload.
+openapi: 3.0.1
+info:
+  title: Binary raw body
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '204':
+          description: stored
+components: {}


### PR DESCRIPTION
## Summary

Fixes `format: binary` being generated as `MultipartFile` (Spring) / `FileUpload`
(Quarkus) in every position. Those types are correct only for a multipart
**upload part**; used anywhere else they compile but cannot work at runtime
(Spring has no `HttpMessageConverter`, and JAX-RS no provider, that reads or
writes them). The binary type is now chosen by the position it appears in.

## The bug

`defineJavaType`/`defineKotlinType` mapped `format: binary` unconditionally to
`MultipartFile`/`FileUpload`, regardless of where the schema was used. So a
binary file **download response** produced `MultipartFile download(...)`, a raw
`application/octet-stream` **request body** produced `@RequestBody MultipartFile`,
and a binary **DTO property** produced a `MultipartFile` field — all uncompilable
in spirit (they only compile because the type exists on the classpath) and
non-functional at runtime.

## The fix

`format: binary` now resolves per position:

| Position | Spring | Quarkus |
|---|---|---|
| multipart upload part | `MultipartFile` | `FileUpload` |
| raw request body | `Resource` | `InputStream` |
| binary response body | `Resource` | `InputStream` |
| binary DTO property (JSON base64) | `byte[]` | `byte[]` (Kotlin `ByteArray`) |

Implementation (surgical — `binary` is the only position-dependent type):

- **Type definers**: the default for a bare binary schema — a DTO property / JSON
  value — becomes `byte[]` / `ByteArray` (Jackson base64-encodes it).
- **API extractors**: `getContentTypes` / `getContentType` is the single funnel
  for both request bodies and response bodies. Its multipart branch now maps a
  binary part explicitly to `MultipartFile` / `FileUpload`; its single-part
  branch maps a binary body/response to `Resource` / `InputStream`. The chosen
  type is keyed on the actual framework (a return type derives its content with
  the annotation-context flag hardcoded to `false`, so that flag can't be used
  for the type decision).

Multipart upload parts are unchanged — the branch that keeps emitting
`MultipartFile` / `FileUpload` is specifically there to preserve them.

## Tests

New fixtures `binarydownload.yaml`, `binaryrawbody.yaml`, `binaryproperty.yaml`,
and golden-snapshot `verify()` tests covering every position × framework ×
language (5 in `CodegenTest`, 3 in `KCodegenTest`). The existing `multipart.yaml`
tests (`generateMultipart` / `quarkusMultipart` / `quarkusClientMultipart`, Java
and Kotlin) continue to lock `MultipartFile` / `FileUpload` for upload parts, so
the two directions are pinned in both.

Full test suite passes (227 tests) with no changes to any existing snapshot.
